### PR TITLE
OAuth authorisation fixes (Twitter, LinkedIn)

### DIFF
--- a/.agents/skills/arrow-resource/SKILL.md
+++ b/.agents/skills/arrow-resource/SKILL.md
@@ -1,27 +1,31 @@
 ---
 name: arrow-resource
-description: Kotlin + Arrow Resource lifecycle management with `Resource`, `ResourceScope`, and `resourceScope`. Use for designing safe acquisition/release of files, streams, DB pools/connections, HTTP clients, or multipart parts; composing resources (including parallel acquisition); or integrating Resource with typed errors and cancellation.
+description: Kotlin + Arrow Resource lifecycle discipline with `Resource`, `ResourceScope`, `resourceScope`, and context parameters. Use for safe acquisition/release of files, streams, DB pools/connections, HTTP clients, background scopes, or multipart parts; preventing resource leaks and use-after-close bugs; designing companion `Resource` builders; using `arrow-autoclose` when only synchronous `AutoCloseable` cleanup is possible; composing resources with typed errors, cancellation, or parallel acquisition.
 ---
 
 # Arrow Resource (Kotlin)
 
 ## Quick start
-- Use `resourceScope { ... }` at lifecycle boundaries.
-- Define each resource with `resource { install(acquire) { a, exitCase -> release } }`.
-- Compose with `.bind()`; use `parZip` for independent parallel acquisition.
-- Read `references/resource.md` for patterns and concrete examples.
+- Treat every disposable handle as scoped: wrap it in `Resource` and acquire it only inside `resourceScope`, `resource {}`, or `Resource.use`.
+- Prefer `arrow.fx.coroutines.resource.context` imports for context-parameter-friendly `resource`, `resourceScope`, `bind`, `install`, and `autoCloseable`.
+- Never return a disposable value from `resourceScope { ... }`, `resource { ... }`, or `resource.use { ... }`; that returns a closed handle.
+- Classes must not allocate owned resources in ordinary constructors. Use a companion builder returning `Resource<Class>` or requiring `context(ResourceScope)`.
+- If suspend `Resource` cannot be used, use `arrow-autoclose`/`AutoCloseable` with the same no-leak discipline.
+- Read `references/resource.md` before writing examples, reviews, or new APIs.
 
 ## Workflow
-1. Identify the acquire step and the release step.
-2. Implement a `Resource<A>` using `install`.
-3. Create reusable constructors on `ResourceScope` when needed.
-4. Compose resources into higher-level resources with `.bind()`.
-5. Execute in `resourceScope` and keep finalizers idempotent.
+1. Identify every owned disposable dependency and its release action.
+2. Move acquisition into a `Resource` recipe or `context(ResourceScope)` builder.
+3. Compose resources into higher-level resources with `.bind()` or context-parameter builders.
+4. Keep resource handles private to the scoped object; expose operations, not the raw handle.
+5. Execute at lifecycle boundaries with `resourceScope`/`.use`, and keep finalizers idempotent.
 
 ## Usage guidance
-- Prefer Resource over `use`/`try/finally` when you need suspend finalizers or MPP support.
-- Use `ExitCase` to handle rollback/cleanup differences.
-- When mixing with typed errors, pick nesting order deliberately to control `ExitCase` seen by finalizers.
+- Prefer `Resource` over `use`/`try/finally` for suspend finalizers, cancellation awareness, composition, or multiplatform code.
+- Use context parameters for scoped capabilities: `context(_: ResourceScope) suspend fun acquire...`.
+- Use `ExitCase` when release behavior depends on success, failure, or cancellation.
+- `Resource` is FP-style ownership: acquisition and finalization are values/effects that compose; hidden side-effectful constructors are a design smell.
+- When changing examples, update and run the bundled `scripts/verify-examples.kt` check.
 
 ## References
-- Load `references/resource.md` for API details and end-to-end examples.
+- Load `references/resource.md` for rules, source links, and typechecked examples.

--- a/.agents/skills/arrow-resource/references/resource.md
+++ b/.agents/skills/arrow-resource/references/resource.md
@@ -1,165 +1,320 @@
 # Arrow Resource (Kotlin) - Practical Guide
 
-Concise reference for Arrow `Resource` and `resourceScope`.
+Use this reference when designing or reviewing Kotlin APIs that own files, streams,
+clients, pools, sockets, workers, database connections, multipart parts, temporary
+directories, or any other disposable handle.
 
 Sources:
-- https://arrow-kt.io/learn/coroutines/resource-safety/
 
+- <https://arrow-kt.io/learn/coroutines/resource-safety/>
+- <https://apidocs.arrow-kt.io/arrow-fx-coroutines/arrow.fx.coroutines/-resource/index.html>
+- <https://apidocs.arrow-kt.io/arrow-fx-coroutines/arrow.fx.coroutines.resource.context/index.html>
+- <https://apidocs.arrow-kt.io/arrow-autoclose/arrow/auto-close-scope.html>
+
+Typechecked representative check: `scripts/verify-examples.kt`.
 
 ## Table of Contents
-- [Core model](#core-model)
-- [Core APIs](#core-apis)
-- [When to use Resource](#when-to-use-resource)
-- [Patterns](#patterns)
-- [Typed errors integration](#typed-errors-integration)
-- [Checklist](#checklist)
 
-## Core model
+- [The Rule](#the-rule)
+- [Core Model](#core-model)
+- [API Surface](#api-surface)
+- [Context-Parameter Style](#context-parameter-style)
+- [Class Design](#class-design)
+- [No Leaking](#no-leaking)
+- [AutoCloseable Without Suspend](#autocloseable-without-suspend)
+- [Typed Errors And ExitCase](#typed-errors-and-exitcase)
+- [Review Checklist](#review-checklist)
+- [Representative Prompts](#representative-prompts)
+
+## The Rule
+
+Resource management is an ownership discipline:
+
+- Every value that needs disposal must be acquired through `Resource`, `ResourceScope.install`, `autoCloseable`, `closeable`, or a higher-level builder that uses them.
+- The raw resource reference must not outlive the scope that acquired it.
+- Do not return raw resource handles from `resourceScope { ... }`, `resource { ... }`, or `resource.use { ... }`.
+- A class that owns resources must not allocate them in an ordinary constructor or initializer. Put acquisition in a companion builder returning `Resource<A>` or requiring `context(ResourceScope)`.
+- If the code cannot be suspend/resource-based, use `arrow-autoclose` and `AutoCloseable`, with the same rule: no resource references escape their close scope.
+
+This is functional-programming resource discipline: acquisition and release are explicit effects that compose. Avoid hidden side-effectful constructors, global mutable handles, or "open now, remember to close later" APIs.
+
+## Core Model
+
 - `typealias Resource<A> = suspend ResourceScope.() -> A`
-- Three phases: acquire -> use -> release.
-- `ExitCase` tells the release phase why it runs: Completed, Failure, Cancelled.
-- Acquisition and release run in `NonCancellable`.
+- A `Resource<A>` is a recipe, not an acquired value.
+- The lifecycle is acquire -> use -> release.
+- Release finalizers run when `resourceScope` or `Resource.use` exits.
+- Finalizers run in reverse acquisition order.
+- `ExitCase` tells the finalizer why it is running: completed, failed, or cancelled.
+- Arrow runs acquire and release in a non-cancellable section. If acquisition fails before the value is acquired, that resource's release does not run; already acquired resources are still released.
 
-## Core APIs
-- `resource { ... }` creates a Resource recipe.
-- `resourceScope { ... }` executes resources and guarantees release.
-- `install(acquire) { resource, exitCase -> release }` registers a finalizer.
-- `.bind()` inside `resourceScope` or `resource` to acquire a Resource.
-- JVM interop: `closeable` wraps `AutoCloseable` safely.
+Use `Resource` when cleanup is suspendable, when cancellation/structured concurrency matters, when resources compose, or when multiplatform support matters.
 
-## When to use Resource
-- Need suspend finalizers.
-- Need MPP-compatible resource management.
-- Want composable acquisition and release with structured concurrency.
+## API Surface
 
-## Patterns
-
-### 1) Resource constructors
-Create reusable constructors on `ResourceScope`:
+For context-parameter-ready Kotlin, import the context package:
 
 ```kotlin
-import arrow.fx.coroutines.ResourceScope
-import arrow.fx.coroutines.install
+import arrow.fx.coroutines.resource.context.Resource
+import arrow.fx.coroutines.resource.context.ResourceScope
+import arrow.fx.coroutines.resource.context.bind
+import arrow.fx.coroutines.resource.context.install
+import arrow.fx.coroutines.resource.context.resource
+import arrow.fx.coroutines.resource.context.resourceScope
+```
+
+The context package provides `Resource`/`ResourceScope` aliases and context-shaped
+functions:
+
+- `context(ResourceScope) suspend fun <A> Resource<A>.bind(): A`
+- `context(ResourceScope) suspend fun <A> install(acquire, release): A`
+- `context(ResourceScope) suspend fun <A : AutoCloseable> autoCloseable(...): A`
+- `fun <A> resource(block: context(ResourceScope) suspend () -> A): Resource<A>`
+- `suspend fun <A> resourceScope(action: context(ResourceScope) suspend () -> A): A`
+
+Use direct `resource(acquire, release)` for one simple resource, and `resource { ... }`
+when the resource is built from other resources:
+
+```kotlin
+import arrow.fx.coroutines.resource.context.Resource
+import arrow.fx.coroutines.resource.context.resource
 
 class UserProcessor {
   fun start() {}
   fun shutdown() {}
 }
 
-suspend fun ResourceScope.userProcessor(): UserProcessor =
-  install({ UserProcessor().also { it.start() } }) { p, _ -> p.shutdown() }
-```
-
-Use as a `Resource` value when you want a recipe:
-
-```kotlin
-import arrow.fx.coroutines.Resource
-import arrow.fx.coroutines.resource
-
-val userProcessor: Resource<UserProcessor> = resource { userProcessor() }
-```
-
-### 2) Composing resources
-
-```kotlin
-import arrow.fx.coroutines.resource
-
-class DataSource { fun connect() {}; fun close() {} }
-class Service(val ds: DataSource, val processor: UserProcessor)
-
-val dataSource: Resource<DataSource> = resource({ DataSource().also { it.connect() } }) { ds, _ -> ds.close() }
-val service: Resource<Service> = resource { Service(dataSource.bind(), userProcessor.bind()) }
-```
-
-### 3) Parallel acquisition
-
-```kotlin
-import arrow.fx.coroutines.resourceScope
-import arrow.fx.coroutines.parZip
-
-suspend fun example(): Unit = resourceScope {
-  val service = parZip({ userProcessor() }, { dataSource.bind() }) { p, ds -> Service(ds, p) }
-  service.processData()
-}
-```
-
-### 4) Temp file with cleanup
-
-```kotlin
-import arrow.fx.coroutines.Resource
-import arrow.fx.coroutines.resource
-import java.io.File
-
-fun tempFileResource(prefix: String, suffix: String? = null): Resource<File> = resource {
-  install(
-    { File.createTempFile(prefix, suffix) },
-    { file, _ -> if (file.exists()) file.delete() }
+fun userProcessorResource(): Resource<UserProcessor> =
+  resource(
+    acquire = { UserProcessor().also { it.start() } },
+    release = { processor, _ -> processor.shutdown() },
   )
-}
 ```
 
-### 5) Kotlin `Source` (or stream-like) resource
+JVM `AutoCloseable` values can be wrapped directly:
 
 ```kotlin
-import arrow.fx.coroutines.Resource
-import arrow.fx.coroutines.resource
-import kotlinx.io.Source
-import kotlinx.io.buffered
-import kotlinx.io.files.Path
-import kotlinx.io.files.SystemFileSystem
+import arrow.fx.coroutines.resource.context.Resource
+import arrow.fx.coroutines.resource.context.autoCloseable
+import arrow.fx.coroutines.resource.context.resource
+import java.io.BufferedReader
+import java.nio.file.Files
+import java.nio.file.Path
 
-fun fileSourceResource(path: String): Resource<Source> = resource {
+fun linesResource(path: Path): Resource<BufferedReader> =
+  resource {
+    autoCloseable { Files.newBufferedReader(path) }
+  }
+```
+
+Inside `resourceScope` or `resource {}`, a `Resource<A>` is acquired with `.bind()`:
+
+```kotlin
+import arrow.fx.coroutines.resource.context.Resource
+import arrow.fx.coroutines.resource.context.bind
+import arrow.fx.coroutines.resource.context.resource
+import arrow.fx.coroutines.resource.context.resourceScope
+
+class Service private constructor(
+  private val processor: UserProcessor,
+) {
+  fun run(): String = processor.toString()
+
+  companion object {
+    fun resource(): Resource<Service> = resource {
+      Service(userProcessorResource().bind())
+    }
+  }
+}
+
+suspend fun runService(): String =
+  resourceScope {
+    Service.resource().bind().run()
+  }
+```
+
+## Context-Parameter Style
+
+Prefer context parameters for reusable scoped constructors. They make the required
+capability visible without requiring callers to thread a `ResourceScope` manually.
+
+```kotlin
+import arrow.fx.coroutines.resource.context.ResourceScope
+import arrow.fx.coroutines.resource.context.install
+
+context(_: ResourceScope)
+suspend fun userProcessor(): UserProcessor =
   install(
-    { SystemFileSystem.source(Path(path)).buffered() },
-    { source, _ -> source.close() }
+    acquire = { UserProcessor().also { it.start() } },
+    release = { processor, _ -> processor.shutdown() },
   )
-}
 ```
 
-### 6) Database pool + per-connection resource
+Use the constructor inside `resource {}` or `resourceScope {}`; their context
+parameter supplies the capability.
 
 ```kotlin
-import arrow.fx.coroutines.Resource
-import arrow.fx.coroutines.resource
-import javax.sql.DataSource
+import arrow.fx.coroutines.resource.context.Resource
+import arrow.fx.coroutines.resource.context.resource
+import arrow.fx.coroutines.resource.context.resourceScope
 
-class Pool : AutoCloseable { override fun close() {} }
+fun processorResource(): Resource<UserProcessor> =
+  resource { userProcessor() }
 
-fun poolResource(): Resource<Pool> = resource(
-  { Pool() },
-  { pool, _ -> pool.close() }
-)
-
-fun connectionResource(ds: DataSource): Resource<java.sql.Connection> = resource(
-  { ds.connection },
-  { c, _ -> c.close() }
-)
+suspend fun process(): Unit =
+  resourceScope {
+    val processor = userProcessor()
+    processor.toString()
+  }
 ```
 
-### 7) Multipart part disposal (looped discovery)
+Use `context(_: ResourceScope)` when the value is only evidence that resource
+installation is allowed. Use `context(resources: ResourceScope)` only when calling
+receiver-style APIs directly.
 
-When parts are discovered in a loop, register a finalizer for each part as you see it.
-Use `onClose` for synchronous cleanup, or `onDispose` for suspend cleanup.
+## Class Design
+
+Bad: the class opens its own resource and relies on consumers to remember a close rule.
 
 ```kotlin
-import arrow.fx.coroutines.Resource
-import arrow.fx.coroutines.resource
+class BadReportStore(path: Path) {
+  private val writer = Files.newBufferedWriter(path)
 
-private fun receiveParts(multipart: Multipart): Resource<Unit> = resource {
-  multipart.forEachPart { part ->
-    onClose { part.dispose() }
-    // If disposal is suspendable, use onDispose { part.dispose() } instead.
-    handle(part)
+  fun append(line: String) {
+    writer.appendLine(line)
   }
 }
 ```
 
-## Typed errors integration
-- `resourceScope` can wrap an `either` block or be nested inside it.
-- Nesting order changes the `ExitCase` observed by finalizers, but release always runs.
-- Choose nesting order based on how you want finalizers to interpret early exits.
+Good: the class accepts an already-acquired private dependency, and the companion owns
+the resource recipe.
 
-## Checklist
-- Make release idempotent.
-- Decide which `ExitCase` values require compensating actions.
-- Prefer composing Resource values over deep nesting of `install` calls.
+```kotlin
+import arrow.fx.coroutines.resource.context.Resource
+import arrow.fx.coroutines.resource.context.ResourceScope
+import arrow.fx.coroutines.resource.context.install
+import arrow.fx.coroutines.resource.context.resource
+import java.io.BufferedWriter
+import java.nio.file.Files
+import java.nio.file.Path
+
+class ReportStore private constructor(
+  private val writer: BufferedWriter,
+) {
+  fun append(line: String) {
+    writer.appendLine(line)
+  }
+
+  companion object {
+    context(_: ResourceScope)
+    suspend fun open(path: Path): ReportStore {
+      val writer = install(
+        acquire = { Files.newBufferedWriter(path) },
+        release = { handle, _ -> handle.close() },
+      )
+      return ReportStore(writer)
+    }
+
+    fun resource(path: Path): Resource<ReportStore> =
+      resource { open(path) }
+  }
+}
+```
+
+Design APIs so consumers work with `ReportStore` inside the scope, not with
+`BufferedWriter` itself. If a lower-level handle must be exposed, expose a scoped
+operation such as `withWriter { ... }`, not a property.
+
+## No Leaking
+
+These are bugs even though they type-check:
+
+```kotlin
+import arrow.fx.coroutines.resource.context.Resource
+import arrow.fx.coroutines.resource.context.bind
+import arrow.fx.coroutines.resource.context.resourceScope
+import arrow.fx.coroutines.use
+import java.io.BufferedReader
+
+suspend fun leakedFromScope(reader: Resource<BufferedReader>): BufferedReader =
+  resourceScope {
+    reader.bind()
+  } // reader is closed here; caller receives a closed handle
+
+suspend fun leakedFromUse(reader: Resource<BufferedReader>): BufferedReader =
+  reader.use { it } // closed before the returned value is used
+```
+
+Return a result computed inside the scope:
+
+```kotlin
+import arrow.fx.coroutines.resource.context.Resource
+import arrow.fx.coroutines.use
+import java.io.BufferedReader
+
+suspend fun firstLine(reader: Resource<BufferedReader>): String? =
+  reader.use { handle -> handle.readLine() }
+```
+
+If multiple resources are acquired in a loop, install each resource as soon as it is
+discovered. Do not collect raw unclosed handles and close them later.
+
+## AutoCloseable Without Suspend
+
+Use `arrow-autoclose` for non-suspend code that must compose multiple
+`AutoCloseable` values without nested `use` blocks.
+
+```kotlin
+import arrow.AutoCloseScope
+import arrow.autoCloseScope
+import java.io.PrintWriter
+import java.util.Scanner
+
+context(scope: AutoCloseScope)
+fun copyLines(input: String, output: String) {
+  val scanner = scope.install(Scanner(input))
+  val writer = scope.install(PrintWriter(output))
+  for (line in scanner) writer.println(line)
+}
+
+fun copyLinesSafely(input: String, output: String): Unit =
+  autoCloseScope {
+    copyLines(input, output)
+  }
+```
+
+Use `Resource` when you need suspend finalizers, `ExitCase`, or cancellation details.
+Use `autoCloseScope` only when synchronous `AutoCloseable.close()` is enough. In both
+cases, the resource handle must stay inside the scope.
+
+## Typed Errors And ExitCase
+
+Resource finalizers always run, but nesting with typed-error builders affects the
+`ExitCase` observed by finalizers.
+
+- `either { resourceScope { raise(error) } }` treats the logical raise as crossing the resource boundary, so finalizers observe cancellation.
+- `resourceScope { either { raise(error) } }` completes the resource scope with an `Either.Left`, so finalizers observe normal completion.
+
+Choose the nesting order based on whether finalizers should treat logical errors like
+rollback-worthy abnormal exits. If finalizers are the same for every `ExitCase`, the
+observable difference usually does not matter.
+
+## Review Checklist
+
+- Every disposable dependency has one owner and one release path.
+- Acquisition is in `Resource`, `context(ResourceScope)`, `resourceScope`, `autoCloseable`, `closeable`, or `autoCloseScope`.
+- No raw resource is returned from `resourceScope`, `resource`, or `.use`.
+- Classes receive already-acquired dependencies through private constructors.
+- Companion builders return `Resource<Class>` or require `context(ResourceScope)`.
+- Finalizers are idempotent and do not assume normal completion unless checking `ExitCase`.
+- Independent resources may be acquired with `parZip`; dependent resources are acquired sequentially.
+- Non-suspend code uses `AutoCloseable`/`autoCloseScope` and follows the same no-leak rule.
+
+## Representative Prompts
+
+Use these to test the skill:
+
+- "Refactor this Ktor client wrapper so it doesn't leak the HTTP client."
+- "Design a repository that owns a database pool and per-request connections using Arrow Resource."
+- "Rewrite this code that returns `resource.use { it }` so the handle cannot escape closed."
+- "Provide a non-suspend AutoCloseable version using arrow-autoclose."

--- a/.agents/skills/arrow-resource/scripts/verify-examples.kt
+++ b/.agents/skills/arrow-resource/scripts/verify-examples.kt
@@ -1,0 +1,120 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+
+//JAVA 17+
+//KOTLIN 2.3.21
+//COMPILE_OPTIONS -Xcontext-parameters
+//DEPS io.arrow-kt:arrow-fx-coroutines-jvm:2.2.2.1
+//DEPS io.arrow-kt:arrow-autoclose-jvm:2.2.2.1
+//DEPS org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0
+
+import arrow.AutoCloseScope
+import arrow.autoCloseScope
+import arrow.fx.coroutines.resource.context.Resource
+import arrow.fx.coroutines.resource.context.ResourceScope
+import arrow.fx.coroutines.resource.context.autoCloseable
+import arrow.fx.coroutines.resource.context.bind
+import arrow.fx.coroutines.resource.context.install
+import arrow.fx.coroutines.resource.context.resource
+import arrow.fx.coroutines.resource.context.resourceScope
+import kotlinx.coroutines.runBlocking
+
+private class TrackedHandle private constructor(
+    private val name: String,
+    private val releases: MutableList<String>,
+) : AutoCloseable {
+    private var closed = false
+
+    fun read(): String {
+        check(!closed) { "$name is already closed" }
+        return "data:$name"
+    }
+
+    override fun close() {
+        if (!closed) {
+            closed = true
+            releases += name
+        }
+    }
+
+    companion object {
+        fun open(name: String, releases: MutableList<String>): TrackedHandle =
+            TrackedHandle(name, releases)
+    }
+}
+
+context(_: ResourceScope)
+private suspend fun trackedHandle(name: String, releases: MutableList<String>): TrackedHandle =
+    install(
+        acquire = { TrackedHandle.open(name, releases) },
+        release = { handle, _ -> handle.close() },
+    )
+
+context(_: ResourceScope)
+private suspend fun autoTrackedHandle(name: String, releases: MutableList<String>): TrackedHandle =
+    autoCloseable { TrackedHandle.open(name, releases) }
+
+private class ManagedClient private constructor(
+    private val primary: TrackedHandle,
+    private val cache: TrackedHandle,
+) {
+    fun fetch(): String =
+        "${primary.read()}|${cache.read()}"
+
+    companion object {
+        context(_: ResourceScope)
+        suspend fun open(releases: MutableList<String>): ManagedClient =
+            ManagedClient(
+                primary = trackedHandle("primary", releases),
+                cache = autoTrackedHandle("cache", releases),
+            )
+
+        fun resource(releases: MutableList<String>): Resource<ManagedClient> =
+            resource { open(releases) }
+    }
+}
+
+private class SyncClient private constructor(
+    private val handle: TrackedHandle,
+) {
+    fun fetch(): String =
+        handle.read()
+
+    companion object {
+        context(scope: AutoCloseScope)
+        fun open(releases: MutableList<String>): SyncClient =
+            SyncClient(scope.install(TrackedHandle.open("sync", releases)))
+    }
+}
+
+suspend fun resourceExample(): List<String> {
+    val releases = mutableListOf<String>()
+
+    val result = resourceScope {
+        val client = ManagedClient.resource(releases).bind()
+        client.fetch()
+    }
+
+    check(result == "data:primary|data:cache")
+    check(releases == listOf("cache", "primary"))
+    return releases
+}
+
+fun autoCloseExample(): List<String> {
+    val releases = mutableListOf<String>()
+
+    val result = autoCloseScope {
+        val client = SyncClient.open(releases)
+        client.fetch()
+    }
+
+    check(result == "data:sync")
+    check(releases == listOf("sync"))
+    return releases
+}
+
+fun main() {
+    runBlocking {
+        check(resourceExample() == listOf("cache", "primary"))
+    }
+    check(autoCloseExample() == listOf("sync"))
+}

--- a/.agents/skills/arrow-typed-errors/SKILL.md
+++ b/.agents/skills/arrow-typed-errors/SKILL.md
@@ -1,37 +1,26 @@
 ---
 name: arrow-typed-errors
-description: Kotlin + Arrow typed error handling using Raise DSL and wrapper types (Either/Option/Ior/Result/nullable), including validation with accumulation, interop with exceptions, and custom error wrappers. Use for designing or refactoring error modeling, converting exception-based flows, building smart constructors, accumulating validation errors, or integrating Outcome/Progress-style wrappers with Arrow.
+description: Models Kotlin logical failures with Arrow's context-parameter Raise DSL and wrappers such as Either, nullable, Option, and Ior. Use when implementing or simplifying typed-error flows, translating error types, replacing verbose Either handling, validating input with accumulation, or selecting an error wrapper.
 ---
 
-# Arrow Typed Errors (Kotlin)
+# Arrow Typed Errors
 
 ## Quick start
-- Classify the failure first: logical failure (typed error) vs exceptional failure (exception).
-- Pick the surface type:
-  - `Raise<E>` + builder (`either {}`/`option {}`/`nullable {}`) for composable logic.
-  - Wrapper type (`Either`/`Option`/`Ior`/`Result`/nullable) for API boundaries.
-- Read `references/typed-errors.md` for API details and patterns before coding if unsure.
+- Distinguish expected domain failures from exceptional faults before selecting an API.
+- For new code, prefer context-parameter computations (`context(_: Raise<E>)`) and run them into a wrapper at a boundary with `either { ... }`, `nullable { ... }`, `option { ... }`, or `ior(...) { ... }`.
+- Use `Either` operators for routine propagation and transformation; do not pattern match only to reconstruct `Left` or `Right`.
+- Use `when` when the domain genuinely branches by case or when matching a multi-state wrapper directly communicates intent.
 
 ## Workflow
-1. Model errors as sealed types.
-2. Implement happy-path logic with Raise DSL (prefer `either {}` or `nullable {}` depending on output).
-3. Guard invariants with `ensure` / `ensureNotNull`.
-4. Interop with external code:
-   - Use `catch`/`Either.catchOrThrow` to convert expected exceptions into typed errors.
-5. Compose with `.bind()` and transform errors with `withError` or `recover`.
-6. For validation across fields or lists, use accumulation (`zipOrAccumulate`, `mapOrAccumulate`, or `accumulate`).
-7. Expose wrapper types at module boundaries; keep Raise internally when possible.
-
-## Patterns to apply
-- **Smart constructors (parse, don't validate)**: make constructors private; expose `invoke` returning `Either`.
-- **Validation accumulation**: use `EitherNel` and `zipOrAccumulate`/`mapOrAccumulate`.
-- **Wrapper choice**:
-  - Prefer nullable for optional values unless nested nullability issues exist; then use `Option`.
-  - Use `Either` for disjoint success/failure; `Ior` only when success + warning is meaningful.
-  - Use `Result` only when errors are `Throwable` and interop with stdlib APIs is required.
-- **Error translation across layers**: use `withError` to map inner errors to outer domain errors.
-- **Drop error types explicitly**: wrap `bind` with `ignoreErrors` when moving from informative error types to `Option`/nullable flows.
-- **Avoid sealed-on-sealed inheritance**: model error hierarchies with composition (wrapper data classes), not sealed inheritance chains.
+1. Model domain failures as focused sealed types.
+2. Choose fail-fast composition or independent validation accumulation.
+3. Implement internal logic in a `Raise<E>` context and expose an appropriate wrapper at the public boundary.
+4. Bind nested typed computations and translate their errors at the layer boundary.
+5. Convert only expected, recoverable exceptions into typed failures.
+6. Inspect the result with a combinator or intentional case analysis at the consumer boundary.
+7. Type-check examples when introducing a less familiar Arrow API or upgrading Arrow/Kotlin.
+8. When changing examples, update and run the bundled `scripts/verify-examples.kt` check.
 
 ## References
-- Load `references/typed-errors.md` for API details, error accumulation, wrapper-specific guidance, and sample snippets.
+- Load [references/typed-errors.md](references/typed-errors.md) for context-parameter API examples, imports, validation, wrapper usage, and the checked sample location.
+- Load [references/best-practices.md](references/best-practices.md) when designing or reviewing code, especially to simplify verbose `Either` handling without turning `when` into a blanket prohibition.

--- a/.agents/skills/arrow-typed-errors/references/best-practices.md
+++ b/.agents/skills/arrow-typed-errors/references/best-practices.md
@@ -1,0 +1,233 @@
+# Arrow Typed Errors: Best Practices and Simplifications
+
+Use this guide when choosing a typed-error design or simplifying code that already returns `Either`. It combines the official Arrow guidance with practical refactoring cases; the objective is concise intent, not elimination of Kotlin `when`. Complete type-checked API examples are in `typed-errors.md` and `scripts/verify-examples.kt`; snippets here use application-shaped placeholder types where the refactoring intent matters.
+
+## Contents
+
+- [Choose the failure channel deliberately](#choose-the-failure-channel-deliberately)
+- [Prefer contextual Raise for workflows](#prefer-contextual-raise-for-workflows)
+- [Replace boilerplate Either branching](#replace-boilerplate-either-branching)
+- [Use when where it expresses the domain](#use-when-where-it-expresses-the-domain)
+- [Translate and recover at boundaries](#translate-and-recover-at-boundaries)
+- [Validate independent inputs together](#validate-independent-inputs-together)
+- [Keep ordinary control flow ordinary](#keep-ordinary-control-flow-ordinary)
+- [Select the smallest wrapper](#select-the-smallest-wrapper)
+- [Keep custom wrappers interoperable](#keep-custom-wrappers-interoperable)
+- [Review checklist](#review-checklist)
+- [Sources](#sources)
+
+## Choose the failure channel deliberately
+
+Model failures that callers are expected to handle in types. Leave infrastructure faults, cancellation, and unrecoverable failures exceptional unless the contract specifically turns one into a domain result.
+
+```kotlin
+sealed interface SaveError {
+    data object DuplicateUsername : SaveError
+}
+
+fun save(username: String): Either<SaveError, Long> =
+    Either.catchOrThrow<SQLException, Long> { insert(username) }
+        .mapLeft { error ->
+            if (error.isUniqueViolation()) SaveError.DuplicateUsername else throw error
+        }
+```
+
+This converts the known duplicate case; it does not flatten every database failure into a misleading domain value.
+
+When two catch branches have identical handling and one exception type is already covered by another, keep only the verified common catch. This is ordinary exception simplification and is compatible with typed conversion; confirm the inheritance relationship in the dependency version before removing a branch.
+
+## Prefer contextual Raise for workflows
+
+For dependent multi-step logic, an internal context-parameter function avoids nested wrapper plumbing while preserving a typed boundary:
+
+```kotlin
+context(_: Raise<ServiceError>)
+fun authenticate(rawId: String): Session {
+    val id = UserId.parse(rawId).mapLeft(ServiceError::InvalidId).bind()
+    val user = findUser(id).bind()
+    return createSession(user).bind()
+}
+
+fun authenticateEither(rawId: String): Either<ServiceError, Session> =
+    either { authenticate(rawId) }
+```
+
+Inside `either {}` or a `Raise<E>` context, do not inspect an `Either` just to propagate it. Translate as needed and call `.bind()`. Consider enabling Arrow's Detekt rule for unused bindable values so a bare `Either` statement in a builder is caught.
+
+## Replace boilerplate Either branching
+
+Use the operator matching the one thing being changed:
+
+| Intent                                          | API                                        |
+| ----------------------------------------------- | ------------------------------------------ |
+| Change successful value only                    | `.map { ... }`                             |
+| Change error value only                         | `.mapLeft { ... }`                         |
+| Continue with another `Either`                  | `.flatMap { ... }` or contextual `.bind()` |
+| Collapse error/success into one value           | `.fold({ ... }, { ... })`                  |
+| Return an actual fallback success value         | `.getOrElse { ... }`                       |
+| Recovery may raise or perform typed-error logic | `.recover { ... }`                         |
+
+Transforming only success:
+
+```kotlin
+fun hasToken(id: UserId): Either<StorageError, Boolean> =
+    restoreToken(id).map { token -> token != null }
+```
+
+Do not spell this as a `when` that recreates the unchanged `Left`.
+
+Translating an error while binding:
+
+```kotlin
+context(_: Raise<ApiError>)
+fun loadDocument(key: String): Document =
+    parseDocument(readPayload(key).bind())
+        .mapLeft { error -> ApiError.InvalidDocument(key, error) }
+        .bind()
+```
+
+Avoid expanding the same operation into a forwarding `when`:
+
+```kotlin
+context(_: Raise<ApiError>)
+fun loadDocument(key: String): Document =
+    when (val parsed = parseDocument(readPayload(key).bind())) {
+        is Either.Left -> raise(ApiError.InvalidDocument(key, parsed.value))
+        is Either.Right -> parsed.value
+    }
+```
+
+The `mapLeft(...).bind()` version says that only the error type changes and that success continues; the `when` version repeats those mechanics.
+
+Consuming an `Either` at a boundary:
+
+```kotlin
+fun hasValidAccessToken(payload: String): Boolean =
+    parseDocument(payload).fold(
+        { false },
+        { document -> document.accessToken != null },
+    )
+```
+
+## Use when where it expresses the domain
+
+`when` is not an anti-pattern. It is appropriate for constructing a typed result from genuine mutually exclusive rules:
+
+```kotlin
+fun adultAge(value: Int): Either<AgeError, Age> = when {
+    value < 0 -> AgeError.Negative.left()
+    value < 18 -> AgeError.Minor.left()
+    else -> Age(value).right()
+}
+```
+
+It is also appropriate when rendering or implementing state-rich ADTs such as `Ior`, `Outcome`, progress states, or a custom loading/content/failure wrapper. Replace `when` only when the branches merely reproduce generic `Either` mechanics and an operator makes the intended change clearer.
+
+## Translate and recover at boundaries
+
+Keep lower-level error types focused, and translate them as they cross a layer:
+
+```kotlin
+context(_: Raise<CheckoutError>)
+fun checkout(rawCard: String): Receipt {
+    val card = withError(CheckoutError::InvalidCard) {
+        parseCard(rawCard)
+    }
+    return charge(card).bind()
+}
+```
+
+Use `.mapLeft` for a pure value mapping on an existing wrapper. Use `withError` when running contextual code. Use `.recover` when an error starts a fallback or may produce a different typed failure:
+
+```kotlin
+fun profile(id: UserId): Either<ProfileError, Profile> =
+    cachedProfile(id).recover { _: CacheMiss ->
+        remoteProfile(id).bind()
+    }
+```
+
+## Validate independent inputs together
+
+Default `Either`/`Raise` behavior fails fast; that is correct for dependent steps. For independent input rules, report all useful defects:
+
+```kotlin
+fun registration(name: String, age: Int): Either<NonEmptyList<InputError>, Registration> = either {
+    zipOrAccumulate(
+        { ensure(name.isNotBlank()) { InputError.BlankName } },
+        { ensure(age >= 18) { InputError.UnderAge(age) } },
+    ) { _, _ -> Registration(name, age) }
+}
+```
+
+For homogeneous collections, use `mapOrAccumulate`; retain indexes when a caller needs to identify invalid entries. Do not accumulate operations with dependencies or side effects merely to return more errors.
+
+When validation is more naturally imperative, Arrow also provides the `accumulate` scope with `ensureOrAccumulate` and `bindOrAccumulate`. In Arrow `2.2.2.1` that API is experimental; opt in only when it makes complex validation materially clearer.
+
+## Keep ordinary control flow ordinary
+
+Typed errors do not require turning ordinary null branching into chains. If one branch supplies a default and the other contains substantive typed-error work, use `if` so both paths remain visible:
+
+```kotlin
+context(_: Raise<StorageError>)
+fun storedDocument(row: StoredRow?): Document =
+    if (row == null) {
+        Document.empty()
+    } else {
+        parseDocument(row.payload)
+            .mapLeft(StorageError::InvalidPayload)
+            .bind()
+    }
+```
+
+Likewise, do not re-run side effects to answer a question about an already loaded value. Parse or inspect the value already in hand:
+
+```kotlin
+fun hasValidAccessToken(payload: String): Boolean =
+    parseDocument(payload).fold(
+        { false },
+        { document -> document.accessToken != null },
+    )
+```
+
+This can replace an API that performs another database query solely to return a derived Boolean.
+
+## Select the smallest wrapper
+
+| Need                                                 | Preferred representation             |
+| ---------------------------------------------------- | ------------------------------------ |
+| Absence without diagnostic detail                    | `A?`                                 |
+| Absence in nested-null/generic/non-null carrier code | `Option<A>`                          |
+| Disjoint logical failure or success                  | `Either<E, A>`                       |
+| Usable success plus warnings/notices                 | `Ior<E, A>`                          |
+| Failure deliberately restricted to thrown values     | `Result<A>`                          |
+| Absence distinct from failure                        | An `Outcome`-style wrapper           |
+| Latest value plus loading/progress                   | A `ProgressiveOutcome`-style wrapper |
+
+Choosing a richer wrapper than required makes every consumer handle states that cannot meaningfully occur.
+
+## Keep custom wrappers interoperable
+
+Create a wrapper only when its extra states are real domain or UI states. If a loading/content/failure or dialog-result ADT needs a Raise DSL, define a dedicated error stratum for non-success cases and build over `Raise<ErrorState>`. This preserves interoperation with `Either<ErrorState, A>` and accumulation APIs.
+
+Its `bind` implementation should exhaustively match the wrapper's states; that is essential logic, unlike matching `Either` merely to forward `Left` and unwrap `Right`.
+
+## Review checklist
+
+- The failure type describes expected, actionable failures rather than every exception.
+- New workflow code uses `arrow.core.raise.context` and context parameters.
+- Each nested `Either` in a contextual flow is bound, with errors translated at its boundary.
+- `.map`, `.mapLeft`, `.fold`, `.getOrElse`, `.recover`, or `.bind()` replaces only boilerplate matching.
+- Remaining `when` branches represent real domain or wrapper-state decisions.
+- Validation accumulates only independent defects.
+- Optional results do not silently erase errors that callers need.
+- Wrapper choice represents no more states than the contract requires.
+- New snippets are type-checked against the project's Arrow and Kotlin versions.
+
+## Sources
+
+- https://arrow-kt.io/learn/typed-errors/working-with-typed-errors/
+- https://arrow-kt.io/learn/typed-errors/validation/
+- https://arrow-kt.io/learn/typed-errors/wrappers/nullable-and-option/
+- https://arrow-kt.io/learn/typed-errors/wrappers/either-and-ior/
+- https://arrow-kt.io/learn/typed-errors/wrappers/outcome-progress/
+- https://arrow-kt.io/learn/typed-errors/wrappers/own-error-types/

--- a/.agents/skills/arrow-typed-errors/scripts/verify-examples.kt
+++ b/.agents/skills/arrow-typed-errors/scripts/verify-examples.kt
@@ -1,33 +1,10 @@
-# Arrow Typed Errors: Context-Parameter API Examples
+///usr/bin/env jbang "$0" "$@" ; exit $?
 
-This reference targets Arrow Core's context-parameter API for Kotlin. The snippets below are represented together in `scripts/verify-examples.kt` and were type-checked with Kotlin `2.3.21`, `-Xcontext-parameters`, and Arrow Core `2.2.2.1`. Kotlin `2.4` is the intended stable context-parameter target; remove the compiler opt-in only when the project compiler supports that.
+//JAVA 17+
+//KOTLIN 2.3.21
+//COMPILE_OPTIONS -Xcontext-parameters
+//DEPS io.arrow-kt:arrow-core:2.2.2.1
 
-## Contents
-- [Sources and imports](#sources-and-imports)
-- [Validated value and Either boundary](#validated-value-and-either-boundary)
-- [Bind and translate nested errors](#bind-and-translate-nested-errors)
-- [Transform and consume Either](#transform-and-consume-either)
-- [Expected exceptions](#expected-exceptions)
-- [Validation accumulation](#validation-accumulation)
-- [Nullable and Option](#nullable-and-option)
-- [Ior for success with notices](#ior-for-success-with-notices)
-- [Wrappers with additional states](#wrappers-with-additional-states)
-
-## Sources and imports
-
-Official documentation used for this reference:
-- https://arrow-kt.io/learn/typed-errors/
-- https://arrow-kt.io/learn/typed-errors/working-with-typed-errors/
-- https://arrow-kt.io/learn/typed-errors/validation/
-- https://arrow-kt.io/learn/typed-errors/wrappers/
-- https://arrow-kt.io/learn/typed-errors/wrappers/nullable-and-option/
-- https://arrow-kt.io/learn/typed-errors/wrappers/either-and-ior/
-- https://arrow-kt.io/learn/typed-errors/wrappers/outcome-progress/
-- https://arrow-kt.io/learn/typed-errors/wrappers/own-error-types/
-
-The official tutorials may show receiver-style functions such as `fun Raise<E>.find(): A`. This skill uses the context-parameter equivalent, `context(_: Raise<E>) fun find(): A`, with imports from `arrow.core.raise.context`.
-
-```kotlin
 import arrow.core.Either
 import arrow.core.Ior
 import arrow.core.NonEmptyList
@@ -54,13 +31,7 @@ import arrow.core.raise.context.nullable
 import arrow.core.raise.context.option
 import arrow.core.raise.context.withError
 import arrow.core.raise.context.zipOrAccumulate
-```
 
-## Validated value and Either boundary
-
-Use `ensure` and `ensureNotNull` for constraints that are logical failures. A context-parameter computation returns its ordinary success value; an `either` boundary turns raised failures into `Either.Left`.
-
-```kotlin
 sealed interface ParseError {
     data object Blank : ParseError
     data class NotANumber(val raw: String) : ParseError
@@ -83,15 +54,7 @@ value class UserId private constructor(val value: Long) {
         }
     }
 }
-```
 
-Hide constructors for values whose invariants matter. For a Kotlin `data class` with a private constructor, also account for the generated `copy()` API; a plain class or an appropriate copy-visibility policy avoids silently reopening invalid construction.
-
-## Bind and translate nested errors
-
-Call `.bind()` whenever an `Either` value should participate in a contextual computation. Translate a lower-level error into the surrounding error type before binding.
-
-```kotlin
 data class User(val id: UserId, val name: String, val email: String?)
 
 sealed interface ServiceError {
@@ -113,11 +76,7 @@ fun loadUser(rawId: String): User {
 
 fun loadUserEither(rawId: String): Either<ServiceError, User> =
     either { loadUser(rawId) }
-```
 
-`mapLeft` is enough when translating an error is a pure mapping. Use `withError` when invoking a contextual computation under a new surrounding error type:
-
-```kotlin
 context(_: Raise<ServiceError>)
 fun loadUserDirect(rawId: String): User {
     val id = withError({ error: ParseError -> ServiceError.InvalidId(error) }) {
@@ -125,15 +84,7 @@ fun loadUserDirect(rawId: String): User {
     }
     return findUser(id).bind()
 }
-```
 
-Use `recover` instead of `mapLeft` when recovery needs to produce a success value or execute typed-error logic that may raise another failure.
-
-## Transform and consume Either
-
-When already holding `Either`, its operators state intent more directly than reconstructing both branches manually.
-
-```kotlin
 fun hasUser(rawId: String): Either<ServiceError, Boolean> =
     loadUserEither(rawId).map { true }
 
@@ -153,23 +104,7 @@ fun loadUserOrFallback(rawId: String): Either<ServiceError, User> =
         val fallbackId = UserId.parse("1").mapLeft(ServiceError::InvalidId).bind()
         findUser(fallbackId).bind()
     }
-```
 
-Use:
-- `.map { ... }` when only the success value changes.
-- `.mapLeft { ... }` when only the failure value changes.
-- `.flatMap { ... }` for a short wrapper-style dependent chain.
-- `.fold({ ... }, { ... })` when both branches produce one boundary value.
-- `.getOrElse { ... }` when a real fallback value exists.
-- `either { ... .bind() ... }` when a longer dependent workflow should read top-to-bottom.
-
-The `recover` example runs another typed computation on failure. Use this only when the fallback is part of the contract; do not conceal a failure merely to avoid handling it.
-
-## Expected exceptions
-
-Convert exceptions into typed failures only when they represent an expected condition in the function's contract. `catchOrThrow<T>` catches the specified exception type and leaves unrelated exceptions exceptional.
-
-```kotlin
 sealed interface StoredError {
     data class InvalidCount(val text: String) : StoredError
 }
@@ -177,17 +112,7 @@ sealed interface StoredError {
 fun parseStoredCount(text: String): Either<StoredError, Int> =
     Either.catchOrThrow<NumberFormatException, Int> { text.toInt() }
         .mapLeft { StoredError.InvalidCount(text) }
-```
 
-For database or network code, catch only recoverable expected exceptions, such as a known uniqueness violation; rethrow failures that do not denote a modeled domain result.
-
-## Validation accumulation
-
-An ordinary `either` flow is fail-fast. Use accumulation only for independent validations where reporting several input defects is useful.
-
-`zipOrAccumulate` combines different independent field checks:
-
-```kotlin
 sealed interface SignupError {
     data object BlankName : SignupError
     data class UnderAge(val age: Int) : SignupError
@@ -212,13 +137,7 @@ class Signup private constructor(val name: String, val age: Int) {
         }
     }
 }
-```
 
-For longer imperative-shaped construction, `accumulate` brings in `ensureOrAccumulate` and related APIs. It is annotated experimental in Arrow `2.2.2.1`, so opt in deliberately; prefer `zipOrAccumulate` for straightforward independent fields.
-
-`mapOrAccumulate` applies one independent validation to collection elements. Preserve indexes when they improve diagnostics:
-
-```kotlin
 sealed interface AuthorError {
     data object EmptyName : AuthorError
 }
@@ -243,13 +162,7 @@ fun validateAuthors(names: Iterable<String>): Either<NonEmptyList<BookError>, Li
             .bind()
     }
 }
-```
 
-## Nullable and Option
-
-Prefer Kotlin nullable types when absence is the only extra state. Use `Option` when generic or reactive code must distinguish an absent element from a present `null`, or when interoperating with an API that cannot carry nulls.
-
-```kotlin
 fun selectEmail(user: User?): String? = nullable {
     user.bind().email.bind()
 }
@@ -261,15 +174,21 @@ fun selectEmailOption(user: Option<User>): Option<String> = option {
 
 fun possibleEmail(rawId: String): String? =
     loadUserEither(rawId).getOrNull()?.email
-```
 
-The last function intentionally discards `ServiceError` at an optional-value boundary. Do not erase a useful error channel accidentally. The receiver-style docs mention `ignoreErrors`; Arrow `2.2.2.1` does not expose that helper through `arrow.core.raise.context`, so contextual code should make this conversion explicit and re-check the API after upgrades.
+sealed interface AgeError {
+    data object Negative : AgeError
+    data object Minor : AgeError
+}
 
-## Ior for success with notices
+@JvmInline
+value class Age(val value: Int)
 
-Use `Ior` only when a computation may return a usable value together with warnings or notices. Supply how notices combine when more than one is accumulated.
+fun adultAge(value: Int): Either<AgeError, Age> = when {
+    value < 0 -> AgeError.Negative.left()
+    value < 18 -> AgeError.Minor.left()
+    else -> Age(value).right()
+}
 
-```kotlin
 context(notices: IorRaise<List<String>>)
 fun normalizeTitle(raw: String): String {
     val title = raw.trim()
@@ -279,21 +198,7 @@ fun normalizeTitle(raw: String): String {
 
 fun normalizedTitle(raw: String): Ior<List<String>, String> =
     ior(List<String>::plus) { normalizeTitle(raw) }
-```
 
-Choose `Either` when warning-plus-success is not meaningful, and choose Kotlin `Result` only when the failure type is intentionally `Throwable` for standard-library or exception-oriented interop.
-
-## Wrappers with additional states
-
-`Option`, `Either`, and `Ior` do not model every useful state machine:
-- Quiver `Outcome` distinguishes `Present`, `Failure`, and `Absent`, where absence is not an error.
-- Pedestal State `ProgressiveOutcome` represents the latest outcome plus progress such as loading; this is useful for UI or `Flow` state.
-
-Do not force either type into plain `Either` when its additional state is meaningful to callers. Conversely, do not introduce a custom wrapper for ordinary success/failure.
-
-When defining a custom wrapper such as loading/content/failure, follow the official custom-wrapper pattern: make its short-circuiting states a coherent error stratum, implement a builder over `Raise<ThatError>`, and implement its `bind` by intentionally matching its ADT states. This is a place where exhaustive `when` is the API implementation, not boilerplate.
-
-```kotlin
 sealed interface Lce<out E, out A> {
     data object Loading : Lce<Nothing, Nothing>
     data class Content<A>(val value: A) : Lce<Nothing, A>
@@ -319,4 +224,23 @@ fun titleScreen(ready: Boolean): Lce<String, String> = lce {
     val title = if (ready) Lce.Content("Ready") else Lce.Loading
     title.bindLce()
 }
-```
+
+fun main() {
+    check(UserId.parse("x").isLeft())
+    check(loadUserEither("1").isRight())
+    check(either { loadUserDirect("x") }.isLeft())
+    check(hasUser("1") == true.right())
+    check(displayName("1") == "Ada")
+    check(loadUserChain("1").isRight())
+    check(loadUserOrFallback("unknown").isRight())
+    check(parseStoredCount("x").isLeft())
+    check(Signup.create("", 12).isLeft())
+    check(Signup.createImperatively("", 12).isLeft())
+    check(validateAuthors(listOf("Ada", "")).isLeft())
+    check(selectEmail(loadUserEither("1").getOrNull()) == "ada@example.test")
+    check(selectEmailOption(loadUserEither("2").getOrNull().toOption()).isNone())
+    check(possibleEmail("2") == null)
+    check(adultAge(20).isRight())
+    check(normalizedTitle(" title ").isBoth())
+    check(titleScreen(false) == Lce.Loading)
+}

--- a/.agents/skills/simplify/SKILL.md
+++ b/.agents/skills/simplify/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: simplify
+description: Simplifies code for clarity without changing behavior. Use when code is working but overly complex, deeply nested, duplicated, or unclear.
+---
+
+# Code Simplification
+
+> [Source](https://github.com/addyosmani/agent-skills/blob/fea75b16472ba87e8c11f13a9e000c3ffdb2d1f5/skills/code-simplification/SKILL.md). Adapted.
+
+## Overview
+
+Simplify code by reducing complexity while preserving exact behavior. The goal is not fewer lines — it's code that is easier to read, understand, modify, and debug. Every simplification must pass a simple test: "Would a new team member understand this faster than the original?"
+
+## When to Use
+
+- After a feature is working and tests pass, but the implementation feels heavier than it needs to be
+- During code review when readability or complexity issues are flagged
+- When you encounter deeply nested logic, long functions, or unclear names
+- When refactoring code written under time pressure
+- When consolidating related logic scattered across files
+- After merging changes that introduced duplication or inconsistency
+
+**When NOT to use:**
+
+- Code is already clean and readable — don't simplify for the sake of it
+- You don't understand what the code does yet — comprehend before you simplify
+- The code is performance-critical and the "simpler" version would be measurably slower
+- You're about to rewrite the module entirely — simplifying throwaway code wastes effort
+
+## The Five Principles
+
+### 1. Preserve Behavior Exactly
+
+Don't change what the code does — only how it expresses it. All inputs, outputs, side effects, error behavior, and edge cases must remain identical. If you're not sure a simplification preserves behavior, don't make it.
+
+```
+ASK BEFORE EVERY CHANGE:
+→ Does this produce the same output for every input?
+→ Does this maintain the same error behavior?
+→ Does this preserve the same side effects and ordering?
+→ Do all existing tests still pass without modification?
+```
+
+### 2. Follow Project Conventions
+
+Simplification means making code more consistent with the codebase, not imposing external preferences. Before simplifying:
+
+```
+1. Read AGENTS.md / CLAUDE.md / project conventions
+2. Study how neighboring code handles similar patterns
+3. Match the project's style for:
+   - Import ordering and module system
+   - Function declaration style
+   - Naming conventions
+   - Error handling patterns
+   - Type annotation depth
+```
+
+Simplification that breaks project consistency is not simplification — it's churn.
+
+### 3. Prefer Clarity Over Cleverness
+
+Explicit code is better than compact code when the compact version requires a mental pause to parse.
+
+**Apply the principle of least power.** When two designs express the same behavior, prefer the one that uses less powerful abstractions: plain functions over classes, immutable records over mutable state, data over behavior. A function is easier to read, test, and compose than a class; a record is easier to inspect than an object with hidden state. This is a tiebreaker, not a mandate — defer to project conventions (Principle 2) and keep abstractions that protect API stability, testability, or real extension points (Principle 4).
+
+### 4. Maintain Balance
+
+Simplification has a failure mode: over-simplification. Watch for these traps:
+
+- **Inlining too aggressively** — removing a helper that gave a concept a name makes the call site harder to read
+- **Combining unrelated logic** — two simple functions merged into one complex function is not simpler
+- **Removing "unnecessary" abstraction** — some abstractions exist for extensibility or testability, not complexity
+- **Optimizing for line count** — fewer lines is not the goal; easier comprehension is
+
+### 5. Scope to What Changed
+
+Default to simplifying recently modified code. Avoid drive-by refactors of unrelated code unless explicitly asked to broaden scope. Unscoped simplification creates noise in diffs and risks unintended regressions.
+
+## The Simplification Process
+
+### Step 1: Understand Before Touching (Chesterton's Fence)
+
+Before changing or removing anything, understand why it exists. This is Chesterton's Fence: if you see a fence across a road and don't understand why it's there, don't tear it down. First understand the reason, then decide if the reason still applies.
+
+```
+BEFORE SIMPLIFYING, ANSWER:
+- What is this code's responsibility?
+- What calls it? What does it call?
+- What are the edge cases and error paths?
+- Are there tests that define the expected behavior?
+- Why might it have been written this way? (Performance? Platform constraint? Historical reason?)
+- Check git blame: what was the original context for this code?
+```
+
+If you can't answer these, you're not ready to simplify. Read more context first.
+
+### Step 2: Identify Simplification Opportunities
+
+Scan for these signals — each one is a concrete pattern, not a vague smell:
+
+- **Deep nesting** (3+ levels) — guard clauses, early returns, or small helpers can flatten the flow
+- **Long functions** (50+ lines) — split by responsibility, not by arbitrary line count
+- **Nested ternaries** — replace with readable branching
+- **Boolean parameter flags** — replace with options objects or separate functions
+- **Repeated conditionals** — extract to a well-named predicate function
+- **Generic or abbreviated names** — rename to describe the content
+- **Misleading names** — rename to reflect actual behavior
+- **Comments explaining "what"** — delete; the code is clear enough. Keep comments that explain "why"
+- **Duplicated logic** — extract the repeated decision or transformation once
+- **Dead code** — remove unused branches, parameters, and helpers (after confirming they're truly dead)
+- **Unnecessary abstractions** — remove wrappers that add indirection without value
+- **Over-abstracted patterns** — interface with one implementation, class that could be a function, typeclass with one instance — replace with the simplest construct that expresses the behavior
+- **Redundant type assertions** — remove casts to types that are already inferred
+
+For detailed signal tables, see [simplification patterns](references/simplification-patterns.md).
+
+### Step 3: Apply Changes Incrementally
+
+Make one simplification at a time. Run tests after each change. **Submit refactoring changes separately from feature or bug fix changes.** A PR that refactors and adds a feature is two PRs — split them.
+
+```
+FOR EACH SIMPLIFICATION:
+1. Make the change
+2. Run the test suite
+3. If tests pass → commit (or continue to next simplification)
+4. If tests fail → revert and reconsider
+```
+
+Avoid batching multiple simplifications into a single untested change. If something breaks, you need to know which simplification caused it.
+
+**The Rule of 500:** If a refactoring would touch more than 500 lines, invest in automation (codemods, sed scripts, AST transforms) rather than making the changes by hand. Manual edits at that scale are error-prone and exhausting to review.
+
+### Step 4: Verify the Result
+
+After all simplifications, step back and evaluate the whole:
+
+```
+COMPARE BEFORE AND AFTER:
+- Is the simplified version genuinely easier to understand?
+- Did you introduce any new patterns inconsistent with the codebase?
+- Is the diff clean and reviewable?
+- Would a teammate approve this change?
+```
+
+If the "simplified" version is harder to understand or review, revert. Not every simplification attempt succeeds.
+
+## Verification
+
+After completing a simplification pass:
+
+- [ ] All existing tests pass without modification
+- [ ] Build succeeds with no new warnings
+- [ ] Linter/formatter passes (no style regressions)
+- [ ] Each simplification is a reviewable, incremental change
+- [ ] The diff is clean — no unrelated changes mixed in
+- [ ] Simplified code follows project conventions (checked against AGENTS.md / CLAUDE.md or equivalent)
+- [ ] No error handling was removed or weakened
+- [ ] No dead code was left behind (unused imports, unreachable branches)
+- [ ] A teammate or review agent would approve the change as a net improvement
+
+## References
+
+- [simplification patterns](references/simplification-patterns.md) — signal tables, common rationalizations, red flags, and test prompts

--- a/.agents/skills/simplify/references/simplification-patterns.md
+++ b/.agents/skills/simplify/references/simplification-patterns.md
@@ -1,0 +1,77 @@
+# Simplification Patterns
+
+## Table of contents
+
+- [Signal catalog](#signal-catalog)
+- [Common rationalizations](#common-rationalizations)
+- [Red flags](#red-flags)
+- [Test prompts](#test-prompts)
+- [Source](#source)
+
+## Signal catalog
+
+Scan for these patterns — each one is a concrete signal, not a vague smell.
+
+### Structural complexity
+
+| Pattern                    | Signal                             | Simplification                                            |
+| -------------------------- | ---------------------------------- | --------------------------------------------------------- |
+| Deep nesting (3+ levels)   | Hard to follow control flow        | Extract conditions into guard clauses or helper functions |
+| Long functions (50+ lines) | Multiple responsibilities          | Split into focused functions with descriptive names       |
+| Nested ternaries           | Requires mental stack to parse     | Replace with if/else chains, switch, or lookup objects    |
+| Boolean parameter flags    | `doThing(true, false, true)`       | Replace with options objects or separate functions        |
+| Repeated conditionals      | Same `if` check in multiple places | Extract to a well-named predicate function                |
+
+### Naming and readability
+
+| Pattern                    | Signal                                         | Simplification                                                           |
+| -------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------ |
+| Generic names              | `data`, `result`, `temp`, `val`, `item`        | Rename to describe the content: `userProfile`, `validationErrors`        |
+| Abbreviated names          | `usr`, `cfg`, `btn`, `evt`                     | Use full words unless the abbreviation is universal (`id`, `url`, `api`) |
+| Misleading names           | Function named `get` that also mutates state   | Rename to reflect actual behavior                                        |
+| Comments explaining "what" | `// increment counter` above `count++`         | Delete the comment — the code is clear enough                            |
+| Comments explaining "why"  | `// Retry because the API is flaky under load` | Keep these — they carry intent the code can't express                    |
+
+### Redundancy
+
+| Pattern                   | Signal                                                       | Simplification                                            |
+| ------------------------- | ------------------------------------------------------------ | --------------------------------------------------------- |
+| Duplicated logic          | Same 5+ lines in multiple places                             | Extract to a shared function                              |
+| Dead code                 | Unreachable branches, unused variables, commented-out blocks | Remove (after confirming it's truly dead)                 |
+| Unnecessary abstractions  | Wrapper that adds no value                                   | Inline the wrapper, call the underlying function directly |
+| Over-engineered patterns  | Factory-for-a-factory, strategy-with-one-strategy            | Replace with the simple direct approach                   |
+| Over-abstracted patterns  | Interface with one implementation, class that could be a function, typeclass with one instance | Replace with the simplest construct that expresses the behavior (principle of least power) |
+| Redundant type assertions | Casting to a type that's already inferred                    | Remove the assertion                                      |
+
+## Common rationalizations
+
+| Rationalization                                      | Reality                                                                                                                                               |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "It's working, no need to touch it"                  | Working code that's hard to read will be hard to fix when it breaks. Simplifying now saves time on every future change.                               |
+| "Fewer lines is always simpler"                      | A 1-line nested ternary is not simpler than a 5-line if/else. Simplicity is about comprehension speed, not line count.                                |
+| "I'll just quickly simplify this unrelated code too" | Unscoped simplification creates noisy diffs and risks regressions in code you didn't intend to change. Stay focused.                                  |
+| "The types make it self-documenting"                 | Types document structure, not intent. A well-named function explains _why_ better than a type signature explains _what_.                              |
+| "This abstraction might be useful later"             | Don't preserve speculative abstractions. If it's not used now, it's complexity without value. Remove it and re-add when needed.                       |
+| "The original author must have had a reason"         | Maybe. Check git blame — apply Chesterton's Fence. But accumulated complexity often has no reason; it's just the residue of iteration under pressure. |
+| "I'll refactor while adding this feature"            | Separate refactoring from feature work. Mixed changes are harder to review, revert, and understand in history.                                        |
+
+## Red flags
+
+- Simplification that requires modifying tests to pass (you likely changed behavior)
+- "Simplified" code that is longer and harder to follow than the original
+- Renaming things to match your preferences rather than project conventions
+- Removing error handling because "it makes the code cleaner"
+- Simplifying code you don't fully understand
+- Batching many simplifications into one large, hard-to-review commit
+- Refactoring code outside the scope of the current task without being asked
+
+## Test prompts
+
+- Simplify this working function without changing behavior; focus on deep nesting and unclear names.
+- Review this recently modified code for readability-only refactors and avoid drive-by changes.
+- Replace nested ternaries and duplicated conditionals with clearer control flow while preserving tests.
+- Identify simplification opportunities in this module, but skip changes that are risky or behavior-changing.
+
+## Source
+
+Adapted from [code-simplification](https://github.com/addyosmani/agent-skills/blob/fea75b16472ba87e8c11f13a9e000c3ffdb2d1f5/skills/code-simplification/SKILL.md) by Addy Osmani with additional patterns from [code-simplifier](https://raw.githubusercontent.com/githubnext/agentics/refs/heads/main/workflows/code-simplifier.md).

--- a/.claude/skills/arrow-resource
+++ b/.claude/skills/arrow-resource
@@ -1,1 +1,0 @@
-../../.agents/skills/arrow-resource

--- a/.claude/skills/arrow-typed-errors
+++ b/.claude/skills/arrow-typed-errors
@@ -1,1 +1,0 @@
-../../.agents/skills/arrow-typed-errors

--- a/.claude/skills/compose-state-hoisting
+++ b/.claude/skills/compose-state-hoisting
@@ -1,1 +1,0 @@
-../../.agents/skills/compose-state-hoisting

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,9 @@ skills-update:
 	npx skills add alexandru/skills -a claude-code github-copilot opencode -y --skill \
 		arrow-resource \
 		arrow-typed-errors \
-		compose-state-hoisting
+		compose-state-hoisting \
+		kotlin-context-parameters \
+		simplify
 
 # Docker setup
 docker-init:

--- a/backend/src/main/kotlin/socialpublish/backend/clients/linkedin/LinkedInApiModule.kt
+++ b/backend/src/main/kotlin/socialpublish/backend/clients/linkedin/LinkedInApiModule.kt
@@ -273,10 +273,8 @@ class LinkedInApiModule(
     }
 
     /** Check if LinkedIn auth exists for the given user */
-    suspend fun hasLinkedInAuth(userUuid: UUIDv7): Boolean {
-        val token = restoreOAuthTokenFromDb(userUuid)
-        return token != null
-    }
+    suspend fun hasLinkedInAuth(userUuid: UUIDv7): Boolean =
+        restoreOAuthTokenFromDb(userUuid) != null
 
     /** Restore OAuth token from database (scoped to the user) */
     private suspend fun restoreOAuthTokenFromDb(
@@ -322,7 +320,6 @@ class LinkedInApiModule(
      */
     suspend fun buildAuthorizeURL(
         config: LinkedInConfig,
-        userUuid: UUIDv7,
         state: String,
     ): ApiResult<String> {
         return try {

--- a/backend/src/main/kotlin/socialpublish/backend/clients/linkedin/LinkedInApiModule.kt
+++ b/backend/src/main/kotlin/socialpublish/backend/clients/linkedin/LinkedInApiModule.kt
@@ -70,9 +70,12 @@ import io.ktor.utils.io.ByteReadChannel
 import java.net.URLEncoder
 import java.security.SecureRandom
 import java.util.Base64
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import socialpublish.backend.clients.linkpreview.LinkPreviewParser
 import socialpublish.backend.common.*
+import socialpublish.backend.common.LoomIO
 import socialpublish.backend.common.jsonCommon
 import socialpublish.backend.common.rethrowIfFatalOrCancelled
 import socialpublish.backend.db.DocumentsDatabase
@@ -184,13 +187,16 @@ class LinkedInApiModule(
      * Generate a cryptographically secure random state string for CSRF
      * protection.
      *
-     * The state parameter prevents CSRF attacks during the OAuth flow. LinkedIn
-     * will return this value in the callback, and we verify it matches the
-     * original.
+     * The state parameter prevents CSRF attacks during the OAuth flow. We store
+     * it in an HTTP-only, SameSite=Lax cookie during authorization, include the
+     * same value in LinkedIn's authorization URL, and require the callback
+     * query parameter to match the cookie before exchanging the authorization
+     * code. SecureRandom can block when entropy is unavailable, so generation
+     * is dispatched to a blocking-friendly dispatcher.
      */
-    fun generateOAuthState(): String {
+    suspend fun generateOAuthState(): String {
         val bytes = ByteArray(32)
-        SecureRandom().nextBytes(bytes)
+        withContext(Dispatchers.LoomIO) { SecureRandom().nextBytes(bytes) }
         return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
     }
 
@@ -301,15 +307,17 @@ class LinkedInApiModule(
      * Constructs the URL to redirect users to LinkedIn for OAuth consent. Uses
      * OpenID Connect (OIDC) scopes: `openid`, `profile`, and `w_member_social`.
      *
-     * Includes a cryptographically secure `state` parameter for CSRF protection
-     * as required by the OAuth 2.0 spec and LinkedIn's API.
+     * Includes the caller-provided `state` parameter for CSRF protection as
+     * required by the OAuth 2.0 spec and LinkedIn's API. The route layer owns
+     * generating the state and storing it in a short-lived HTTP-only cookie;
+     * this method only embeds that value into the provider redirect URL.
      *
      * **API Reference:**
      * - [Authorization Code
      *   Flow](https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow)
      *
-     * @param sessionToken session token to include in callback URL for state
-     *   verification
+     * @param state opaque CSRF token generated for this OAuth authorization
+     *   attempt and later verified against the callback cookie
      * @return Authorization URL to redirect the user to, or an error
      */
     suspend fun buildAuthorizeURL(

--- a/backend/src/main/kotlin/socialpublish/backend/clients/linkedin/LinkedInApiModule.kt
+++ b/backend/src/main/kotlin/socialpublish/backend/clients/linkedin/LinkedInApiModule.kt
@@ -71,8 +71,6 @@ import java.net.URLEncoder
 import java.security.SecureRandom
 import java.util.Base64
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import socialpublish.backend.clients.linkpreview.LinkPreviewParser
 import socialpublish.backend.common.*
 import socialpublish.backend.common.jsonCommon
@@ -180,9 +178,7 @@ class LinkedInApiModule(
         }
     }
 
-    private fun getCallbackUrl(sessionToken: String): String {
-        return "$baseUrl/api/linkedin/callback?access_token=${URLEncoder.encode(sessionToken, "UTF-8")}"
-    }
+    private val callbackUrl = "$baseUrl/api/linkedin/callback"
 
     /**
      * Generate a cryptographically secure random state string for CSRF
@@ -192,48 +188,10 @@ class LinkedInApiModule(
      * will return this value in the callback, and we verify it matches the
      * original.
      */
-    private fun generateOAuthState(): String {
+    fun generateOAuthState(): String {
         val bytes = ByteArray(32)
         SecureRandom().nextBytes(bytes)
         return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
-    }
-
-    /** Save OAuth state to database for verification during callback */
-    private suspend fun saveOAuthState(
-        state: String,
-        sessionToken: String,
-        userUuid: UUIDv7,
-    ) {
-        val _ =
-            documentsDb.createOrUpdate(
-                kind = "linkedin-oauth-state",
-                payload =
-                    """{"state":"$state","sessionToken":"$sessionToken"}""",
-                userUuid = userUuid,
-                searchKey = state,
-                tags = emptyList(),
-            )
-    }
-
-    /** Verify and consume OAuth state during callback */
-    suspend fun verifyOAuthState(state: String, userUuid: UUIDv7): String? {
-        val doc =
-            documentsDb.searchByKey(state, userUuid).getOrElse { throw it }
-        return if (doc != null && doc.kind == "linkedin-oauth-state") {
-            // State found and valid (we don't delete it, but could track usage)
-            // In production, we might want to track used states to prevent
-            // replay attacks
-            try {
-                val json = Json.parseToJsonElement(doc.payload)
-                json.jsonObject["sessionToken"]?.jsonPrimitive?.content
-            } catch (e: Throwable) {
-                rethrowIfFatalOrCancelled(e)
-                logger.warn(e) { "Failed to parse OAuth state from DB" }
-                null
-            }
-        } else {
-            null
-        }
     }
 
     /**
@@ -356,16 +314,10 @@ class LinkedInApiModule(
      */
     suspend fun buildAuthorizeURL(
         config: LinkedInConfig,
-        sessionToken: String,
         userUuid: UUIDv7,
+        state: String,
     ): ApiResult<String> {
         return try {
-            val callbackUrl = getCallbackUrl(sessionToken)
-            val state = generateOAuthState()
-
-            // Save state for verification during callback
-            saveOAuthState(state, sessionToken, userUuid)
-
             val authUrl =
                 "${config.authorizationUrl}?response_type=code" +
                     "&client_id=${URLEncoder.encode(config.clientId, "UTF-8")}" +

--- a/backend/src/main/kotlin/socialpublish/backend/clients/twitter/TwitterApiModule.kt
+++ b/backend/src/main/kotlin/socialpublish/backend/clients/twitter/TwitterApiModule.kt
@@ -5,6 +5,8 @@ package socialpublish.backend.clients.twitter
 import arrow.core.Either
 import arrow.core.getOrElse
 import arrow.core.left
+import arrow.core.raise.context.bind
+import arrow.core.raise.either
 import arrow.core.right
 import arrow.fx.coroutines.Resource
 import arrow.fx.coroutines.resource
@@ -37,6 +39,7 @@ import org.jsoup.Jsoup
 import socialpublish.backend.common.*
 import socialpublish.backend.common.jsonCommon
 import socialpublish.backend.common.rethrowIfFatalOrCancelled
+import socialpublish.backend.db.DBException
 import socialpublish.backend.db.DocumentsDatabase
 import socialpublish.backend.db.UUIDv7
 import socialpublish.backend.db.UserSession
@@ -102,65 +105,40 @@ class TwitterApiModule(
 
     private val callbackUrl = "$baseUrl/api/twitter/callback"
 
-    /** Check if Twitter auth exists for the given user */
-    suspend fun hasTwitterAuth(userUuid: UUIDv7): Boolean {
-        val token = restoreOauthTokenFromDb(userUuid)
-        return token != null
-    }
+    /** Parse payload to check for a valid access token without DB lookups. */
+    fun hasValidAccessToken(payload: String): Boolean =
+        TwitterOAuthDocument.parse(payload).fold({ false }) {
+            it.accessToken != null
+        }
 
     /** Restore OAuth token from database (scoped to the user) */
     private suspend fun restoreOauthTokenFromDb(
         userUuid: UUIDv7
-    ): TwitterOAuthToken? {
-        val doc =
-            documentsDb
-                .searchByKey("twitter-oauth-token:$userUuid", userUuid)
-                .getOrElse { throw it }
-        return if (doc != null) {
-            parseTwitterOAuthDocument(doc.payload)?.accessToken
-        } else {
-            null
+    ): ApiResult<TwitterOAuthToken?> =
+        when (val document = loadTwitterOAuthDocument(userUuid)) {
+            is Either.Right -> document.value.accessToken.right()
+            is Either.Left -> document.value.toTwitterApiError().left()
         }
-    }
-
-    /**
-     * Parse a Twitter OAuth document payload with backward compatibility.
-     *
-     * New format: `{"accessToken":{...},"pendingRequest":{...}}` Old format:
-     * `{"key":"...","secret":"..."}`
-     */
-    private fun parseTwitterOAuthDocument(
-        payload: String
-    ): TwitterOAuthDocument? {
-        return try {
-            Json.decodeFromString<TwitterOAuthDocument>(payload)
-        } catch (e: Throwable) {
-            // Fall back to old format: bare TwitterOAuthToken
-            try {
-                val oldToken = Json.decodeFromString<TwitterOAuthToken>(payload)
-                TwitterOAuthDocument(accessToken = oldToken)
-            } catch (e2: Throwable) {
-                rethrowIfFatalOrCancelled(e2)
-                logger.warn(e2) {
-                    "Failed to parse Twitter OAuth token from DB"
-                }
-                null
-            }
-        }
-    }
 
     /** Load the full OAuth document, or return an empty one if none exists. */
     private suspend fun loadTwitterOAuthDocument(
         userUuid: UUIDv7
-    ): TwitterOAuthDocument {
+    ): Either<DBException, TwitterOAuthDocument> = either {
         val doc =
             documentsDb
                 .searchByKey("twitter-oauth-token:$userUuid", userUuid)
-                .getOrElse { throw it }
-        return if (doc != null) {
-            parseTwitterOAuthDocument(doc.payload) ?: TwitterOAuthDocument()
-        } else {
+                .bind()
+        if (doc == null) {
             TwitterOAuthDocument()
+        } else {
+            TwitterOAuthDocument.parse(doc.payload)
+                .mapLeft {
+                    DBException(
+                        "Invalid Twitter OAuth document payload for user $userUuid",
+                        it,
+                    )
+                }
+                .bind()
         }
     }
 
@@ -168,19 +146,27 @@ class TwitterApiModule(
     private suspend fun saveTwitterOAuthDocument(
         userUuid: UUIDv7,
         document: TwitterOAuthDocument,
-    ) {
+    ): Either<DBException, Unit> = either {
         val _ =
-            documentsDb.createOrUpdate(
-                kind = "twitter-oauth-token",
-                payload =
-                    Json.encodeToString(
-                        TwitterOAuthDocument.serializer(),
-                        document,
-                    ),
-                userUuid = userUuid,
-                searchKey = "twitter-oauth-token:$userUuid",
-                tags = emptyList(),
-            )
+            documentsDb
+                .createOrUpdate(
+                    kind = "twitter-oauth-token",
+                    payload = document.toJson(),
+                    userUuid = userUuid,
+                    searchKey = "twitter-oauth-token:$userUuid",
+                    tags = emptyList(),
+                )
+                .bind()
+        Unit
+    }
+
+    private fun DBException.toTwitterApiError(): ApiError {
+        logger.error(this) { "Twitter OAuth database error" }
+        return CaughtException(
+            status = 500,
+            module = "twitter",
+            errorMessage = "Twitter OAuth database error",
+        )
     }
 
     /** Build authorization URL for OAuth flow */
@@ -194,17 +180,23 @@ class TwitterApiModule(
             val authUrl = service.getAuthorizationUrl(token)
 
             // Store pending request token in existing auth document
-            val existingDoc = loadTwitterOAuthDocument(userUuid)
+            val existingDoc =
+                loadTwitterOAuthDocument(userUuid).getOrElse {
+                    return it.toTwitterApiError().left()
+                }
             saveTwitterOAuthDocument(
-                userUuid,
-                existingDoc.copy(
-                    pendingRequest =
-                        TwitterOAuthRequestToken(
-                            token = token.token,
-                            secret = token.tokenSecret,
-                        )
-                ),
-            )
+                    userUuid,
+                    existingDoc.copy(
+                        pendingRequest =
+                            TwitterOAuthRequestToken(
+                                token = token.token,
+                                secret = token.tokenSecret,
+                            )
+                    ),
+                )
+                .getOrElse {
+                    return it.toTwitterApiError().left()
+                }
 
             authUrl.right()
         } catch (e: Throwable) {
@@ -227,7 +219,10 @@ class TwitterApiModule(
         userUuid: UUIDv7,
     ): ApiResult<Unit> {
         return try {
-            val existingDoc = loadTwitterOAuthDocument(userUuid)
+            val existingDoc =
+                loadTwitterOAuthDocument(userUuid).getOrElse {
+                    return it.toTwitterApiError().left()
+                }
             val pending = existingDoc.pendingRequest
 
             if (pending == null) {
@@ -270,12 +265,15 @@ class TwitterApiModule(
                 )
 
             saveTwitterOAuthDocument(
-                userUuid,
-                existingDoc.copy(
-                    accessToken = authorizedToken,
-                    pendingRequest = null,
-                ),
-            )
+                    userUuid,
+                    existingDoc.copy(
+                        accessToken = authorizedToken,
+                        pendingRequest = null,
+                    ),
+                )
+                .getOrElse {
+                    return it.toTwitterApiError().left()
+                }
 
             Unit.right()
         } catch (e: Throwable) {
@@ -414,7 +412,9 @@ class TwitterApiModule(
 
             // Get OAuth token
             val token =
-                restoreOauthTokenFromDb(userUuid)
+                restoreOauthTokenFromDb(userUuid).getOrElse {
+                    return it.left()
+                }
                     ?: return ValidationError(
                             status = 401,
                             errorMessage =
@@ -427,10 +427,11 @@ class TwitterApiModule(
             val mediaIds = mutableListOf<String>()
             if (!request.images.isNullOrEmpty()) {
                 for (imageUuid in request.images) {
-                    when (val result = uploadMedia(config, token, imageUuid)) {
-                        is Either.Right -> mediaIds.add(result.value)
-                        is Either.Left -> return result.value.left()
-                    }
+                    mediaIds.add(
+                        uploadMedia(config, token, imageUuid).getOrElse {
+                            return it.left()
+                        }
+                    )
                 }
             }
 

--- a/backend/src/main/kotlin/socialpublish/backend/clients/twitter/TwitterApiModule.kt
+++ b/backend/src/main/kotlin/socialpublish/backend/clients/twitter/TwitterApiModule.kt
@@ -30,7 +30,6 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.json
-import java.net.URLEncoder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
@@ -101,9 +100,7 @@ class TwitterApiModule(
         return builder.build(TwitterApi(config))
     }
 
-    private fun getCallbackUrl(sessionToken: String): String {
-        return "$baseUrl/api/twitter/callback?access_token=${URLEncoder.encode(sessionToken, "UTF-8")}"
-    }
+    private val callbackUrl = "$baseUrl/api/twitter/callback"
 
     /** Check if Twitter auth exists for the given user */
     suspend fun hasTwitterAuth(userUuid: UUIDv7): Boolean {
@@ -120,28 +117,95 @@ class TwitterApiModule(
                 .searchByKey("twitter-oauth-token:$userUuid", userUuid)
                 .getOrElse { throw it }
         return if (doc != null) {
-            try {
-                Json.decodeFromString<TwitterOAuthToken>(doc.payload)
-            } catch (e: Throwable) {
-                rethrowIfFatalOrCancelled(e)
-                logger.warn(e) { "Failed to parse Twitter OAuth token from DB" }
-                null
-            }
+            parseTwitterOAuthDocument(doc.payload)?.accessToken
         } else {
             null
         }
     }
 
+    /**
+     * Parse a Twitter OAuth document payload with backward compatibility.
+     *
+     * New format: `{"accessToken":{...},"pendingRequest":{...}}` Old format:
+     * `{"key":"...","secret":"..."}`
+     */
+    private fun parseTwitterOAuthDocument(
+        payload: String
+    ): TwitterOAuthDocument? {
+        return try {
+            Json.decodeFromString<TwitterOAuthDocument>(payload)
+        } catch (e: Throwable) {
+            // Fall back to old format: bare TwitterOAuthToken
+            try {
+                val oldToken = Json.decodeFromString<TwitterOAuthToken>(payload)
+                TwitterOAuthDocument(accessToken = oldToken)
+            } catch (e2: Throwable) {
+                rethrowIfFatalOrCancelled(e2)
+                logger.warn(e2) {
+                    "Failed to parse Twitter OAuth token from DB"
+                }
+                null
+            }
+        }
+    }
+
+    /** Load the full OAuth document, or return an empty one if none exists. */
+    private suspend fun loadTwitterOAuthDocument(
+        userUuid: UUIDv7
+    ): TwitterOAuthDocument {
+        val doc =
+            documentsDb
+                .searchByKey("twitter-oauth-token:$userUuid", userUuid)
+                .getOrElse { throw it }
+        return if (doc != null) {
+            parseTwitterOAuthDocument(doc.payload) ?: TwitterOAuthDocument()
+        } else {
+            TwitterOAuthDocument()
+        }
+    }
+
+    /** Save OAuth document to database */
+    private suspend fun saveTwitterOAuthDocument(
+        userUuid: UUIDv7,
+        document: TwitterOAuthDocument,
+    ) {
+        val _ =
+            documentsDb.createOrUpdate(
+                kind = "twitter-oauth-token",
+                payload =
+                    Json.encodeToString(
+                        TwitterOAuthDocument.serializer(),
+                        document,
+                    ),
+                userUuid = userUuid,
+                searchKey = "twitter-oauth-token:$userUuid",
+                tags = emptyList(),
+            )
+    }
+
     /** Build authorization URL for OAuth flow */
     suspend fun buildAuthorizeURL(
         config: TwitterConfig,
-        sessionToken: String,
+        userUuid: UUIDv7,
     ): ApiResult<String> {
         return try {
-            val callbackUrl = getCallbackUrl(sessionToken)
             val service = createOAuthService(config, callbackUrl)
             val token = withContext(Dispatchers.LoomIO) { service.requestToken }
             val authUrl = service.getAuthorizationUrl(token)
+
+            // Store pending request token in existing auth document
+            val existingDoc = loadTwitterOAuthDocument(userUuid)
+            saveTwitterOAuthDocument(
+                userUuid,
+                existingDoc.copy(
+                    pendingRequest =
+                        TwitterOAuthRequestToken(
+                            token = token.token,
+                            secret = token.tokenSecret,
+                        )
+                ),
+            )
+
             authUrl.right()
         } catch (e: Throwable) {
             rethrowIfFatalOrCancelled(e)
@@ -163,11 +227,36 @@ class TwitterApiModule(
         userUuid: UUIDv7,
     ): ApiResult<Unit> {
         return try {
-            // Twitter's access token endpoint doesn't require the request token
-            // secret
-            // in the OAuth signature, only the oauth_token and oauth_verifier
-            // parameters
-            val reqToken = OAuth1RequestToken(token, "")
+            val existingDoc = loadTwitterOAuthDocument(userUuid)
+            val pending = existingDoc.pendingRequest
+
+            if (pending == null) {
+                logger.warn {
+                    "No pending request token found for user $userUuid"
+                }
+                return RequestError(
+                        status = 400,
+                        module = "twitter",
+                        errorMessage =
+                            "Authorization could not be verified. Please try again.",
+                    )
+                    .left()
+            }
+
+            if (pending.token != token) {
+                logger.warn {
+                    "Callback token mismatch: expected ${pending.token}, got $token"
+                }
+                return RequestError(
+                        status = 400,
+                        module = "twitter",
+                        errorMessage =
+                            "Authorization could not be verified. Please try again.",
+                    )
+                    .left()
+            }
+
+            val reqToken = OAuth1RequestToken(token, pending.secret)
             val service = createOAuthService(config)
             val accessToken =
                 withContext(Dispatchers.LoomIO) {
@@ -180,18 +269,13 @@ class TwitterApiModule(
                     secret = accessToken.tokenSecret,
                 )
 
-            val _ =
-                documentsDb.createOrUpdate(
-                    kind = "twitter-oauth-token",
-                    payload =
-                        Json.encodeToString(
-                            TwitterOAuthToken.serializer(),
-                            authorizedToken,
-                        ),
-                    userUuid = userUuid,
-                    searchKey = "twitter-oauth-token:$userUuid",
-                    tags = emptyList(),
-                )
+            saveTwitterOAuthDocument(
+                userUuid,
+                existingDoc.copy(
+                    accessToken = authorizedToken,
+                    pendingRequest = null,
+                ),
+            )
 
             Unit.right()
         } catch (e: Throwable) {

--- a/backend/src/main/kotlin/socialpublish/backend/clients/twitter/models.kt
+++ b/backend/src/main/kotlin/socialpublish/backend/clients/twitter/models.kt
@@ -1,10 +1,9 @@
 package socialpublish.backend.clients.twitter
 
 import arrow.core.Either
-import arrow.core.left
-import arrow.core.right
+import arrow.core.raise.context.either
+import arrow.core.raise.context.raise
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import socialpublish.backend.common.jsonCommon
 
 @Serializable data class TwitterOAuthToken(val key: String, val secret: String)
@@ -41,40 +40,29 @@ data class TwitterOAuthDocument(
          */
         fun parse(
             payload: String
-        ): Either<IllegalArgumentException, TwitterOAuthDocument> {
-            return try {
-                val document =
-                    json.decodeFromString<TwitterOAuthDocument>(payload)
-                if (
-                    document.accessToken != null ||
-                        document.pendingRequest != null
-                ) {
-                    document.right()
-                } else {
-                    parseBareToken(payload).fold({ document.right() }) { token
-                        ->
-                        TwitterOAuthDocument(accessToken = token).right()
-                    }
-                }
-            } catch (wrapperError: IllegalArgumentException) {
-                parseBareToken(payload).map {
-                    TwitterOAuthDocument(accessToken = it)
+        ): Either<IllegalArgumentException, TwitterOAuthDocument> = either {
+            try {
+                val ref = json.decodeFromString<TwitterOAuthDocument>(payload)
+                if (ref.accessToken == null && ref.pendingRequest == null)
+                    throw IllegalArgumentException(
+                        "Both fields missing from payload"
+                    )
+                ref
+            } catch (e: IllegalArgumentException) {
+                try {
+                    val t = json.decodeFromString<TwitterOAuthToken>(payload)
+                    TwitterOAuthDocument(accessToken = t)
+                } catch (e2: IllegalArgumentException) {
+                    e.addSuppressed(e2)
+                    raise(
+                        IllegalArgumentException(
+                            "Invalid TwitterOAuthDocument",
+                            e,
+                        )
+                    )
                 }
             }
         }
-
-        private fun parseBareToken(
-            payload: String
-        ): Either<IllegalArgumentException, TwitterOAuthToken> =
-            try {
-                json.decodeFromString<TwitterOAuthToken>(payload).right()
-            } catch (tokenError: IllegalArgumentException) {
-                IllegalArgumentException(
-                        "Invalid Twitter OAuth document payload",
-                        tokenError,
-                    )
-                    .left()
-            }
     }
 
     fun toJson(): String = json.encodeToString(this)

--- a/backend/src/main/kotlin/socialpublish/backend/clients/twitter/models.kt
+++ b/backend/src/main/kotlin/socialpublish/backend/clients/twitter/models.kt
@@ -1,6 +1,11 @@
 package socialpublish.backend.clients.twitter
 
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import socialpublish.backend.common.jsonCommon
 
 @Serializable data class TwitterOAuthToken(val key: String, val secret: String)
 
@@ -22,7 +27,58 @@ data class TwitterOAuthRequestToken(val token: String, val secret: String)
 data class TwitterOAuthDocument(
     val accessToken: TwitterOAuthToken? = null,
     val pendingRequest: TwitterOAuthRequestToken? = null,
-)
+) {
+    companion object {
+        private val json = jsonCommon
+
+        /**
+         * Parse a persisted Twitter OAuth document.
+         *
+         * New records use this wrapper shape so the OAuth 1.0a request-token
+         * secret can be preserved between authorize and callback. Older records
+         * contain a bare [TwitterOAuthToken]; those are still accepted and
+         * wrapped as [accessToken] to preserve DB compatibility.
+         */
+        fun parse(
+            payload: String
+        ): Either<IllegalArgumentException, TwitterOAuthDocument> {
+            return try {
+                val document =
+                    json.decodeFromString<TwitterOAuthDocument>(payload)
+                if (
+                    document.accessToken != null ||
+                        document.pendingRequest != null
+                ) {
+                    document.right()
+                } else {
+                    parseBareToken(payload).fold({ document.right() }) { token
+                        ->
+                        TwitterOAuthDocument(accessToken = token).right()
+                    }
+                }
+            } catch (wrapperError: IllegalArgumentException) {
+                parseBareToken(payload).map {
+                    TwitterOAuthDocument(accessToken = it)
+                }
+            }
+        }
+
+        private fun parseBareToken(
+            payload: String
+        ): Either<IllegalArgumentException, TwitterOAuthToken> =
+            try {
+                json.decodeFromString<TwitterOAuthToken>(payload).right()
+            } catch (tokenError: IllegalArgumentException) {
+                IllegalArgumentException(
+                        "Invalid Twitter OAuth document payload",
+                        tokenError,
+                    )
+                    .left()
+            }
+    }
+
+    fun toJson(): String = json.encodeToString(this)
+}
 
 @Serializable data class TwitterMediaResponse(val media_id_string: String)
 

--- a/backend/src/main/kotlin/socialpublish/backend/clients/twitter/models.kt
+++ b/backend/src/main/kotlin/socialpublish/backend/clients/twitter/models.kt
@@ -4,6 +4,26 @@ import kotlinx.serialization.Serializable
 
 @Serializable data class TwitterOAuthToken(val key: String, val secret: String)
 
+/**
+ * Represents a pending OAuth 1.0a request token during the authorize step,
+ * including the token secret required for the access-token exchange.
+ */
+@Serializable
+data class TwitterOAuthRequestToken(val token: String, val secret: String)
+
+/**
+ * Backward-compatible wrapper for the `twitter-oauth-token` document payload.
+ *
+ * Existing documents contain bare {@link TwitterOAuthToken} JSON. This wrapper
+ * adds an optional [pendingRequest] field for the request-token secret, while
+ * keeping the final [accessToken] in the same document.
+ */
+@Serializable
+data class TwitterOAuthDocument(
+    val accessToken: TwitterOAuthToken? = null,
+    val pendingRequest: TwitterOAuthRequestToken? = null,
+)
+
 @Serializable data class TwitterMediaResponse(val media_id_string: String)
 
 @Serializable data class TwitterPostResponse(val data: TwitterPostData)

--- a/backend/src/main/kotlin/socialpublish/backend/server/Server.kt
+++ b/backend/src/main/kotlin/socialpublish/backend/server/Server.kt
@@ -618,11 +618,7 @@ fun startServer(
                                         call.respondWithNotConfigured("Twitter")
                                         return@withSession
                                     }
-                            twitterRoutes.authorizeRoute(
-                                twitterConfig,
-                                authRoutes.extractAccessToken(call).orEmpty(),
-                                call,
-                            )
+                            twitterRoutes.authorizeRoute(twitterConfig, call)
                         }
                     }
                     .describe {
@@ -668,11 +664,7 @@ fun startServer(
                                         )
                                         return@withSession
                                     }
-                            linkedInRoutes.authorizeRoute(
-                                linkedInConfig,
-                                authRoutes.extractAccessToken(call).orEmpty(),
-                                call,
-                            )
+                            linkedInRoutes.authorizeRoute(linkedInConfig, call)
                         }
                     }
                     .describe {

--- a/backend/src/main/kotlin/socialpublish/backend/server/openapi.kt
+++ b/backend/src/main/kotlin/socialpublish/backend/server/openapi.kt
@@ -14,7 +14,6 @@ fun Operation.Builder.documentSecurityRequirements() {
     security {
         // Each call = an OR alternative
         requirement("bearerAuth")
-        requirement("accessTokenQuery")
         requirement("accessTokenCookie")
     }
 }
@@ -24,14 +23,6 @@ fun Application.configureOpenApiSecuritySchemes() {
         name = "bearerAuth",
         description = "Session token via Authorization: Bearer <token>",
         bearerFormat = "session-token",
-    )
-
-    registerApiKeySecurityScheme(
-        name = "accessTokenQuery",
-        keyName = "access_token",
-        keyLocation = SecuritySchemeIn.QUERY,
-        description =
-            "Session token via ?access_token=... (discouraged, but supported)",
     )
 
     registerApiKeySecurityScheme(
@@ -68,19 +59,7 @@ inline fun <reified T : Any> Responses.Builder.documentNewPostResponses() {
 fun Responses.Builder.documentOAuthCallbackResponses() {
     HttpStatusCode.Found {
         description =
-            "Successful authorization, redirects to account page (302 Found)"
-    }
-    HttpStatusCode.BadRequest {
-        description = "Missing required parameters (code, state, or verifier)"
-        schema = jsonSchema<ErrorResponse>()
-    }
-    HttpStatusCode.Unauthorized {
-        description = "State parameter mismatch or authorization failed"
-        schema = jsonSchema<ErrorResponse>()
-    }
-    HttpStatusCode.InternalServerError {
-        description = "Failed to save authorization token"
-        schema = jsonSchema<ErrorResponse>()
+            "Redirects to /account on success, or /account?error=... on failure"
     }
 }
 

--- a/backend/src/main/kotlin/socialpublish/backend/server/routes/AuthRoutes.kt
+++ b/backend/src/main/kotlin/socialpublish/backend/server/routes/AuthRoutes.kt
@@ -237,9 +237,6 @@ class AuthRoutes(
         call.request.cookies["access_token"]?.let {
             return it
         }
-        call.request.queryParameters["access_token"]?.let {
-            return it
-        }
         return null
     }
 }

--- a/backend/src/main/kotlin/socialpublish/backend/server/routes/LinkedInRoutes.kt
+++ b/backend/src/main/kotlin/socialpublish/backend/server/routes/LinkedInRoutes.kt
@@ -45,6 +45,7 @@ class LinkedInRoutes(
                 maxAge = 600,
                 path = "/",
                 httpOnly = true,
+                extensions = mapOf("SameSite" to "Lax"),
             )
         )
 
@@ -87,6 +88,7 @@ class LinkedInRoutes(
                 maxAge = 0,
                 path = "/",
                 httpOnly = true,
+                extensions = mapOf("SameSite" to "Lax"),
             )
         )
 

--- a/backend/src/main/kotlin/socialpublish/backend/server/routes/LinkedInRoutes.kt
+++ b/backend/src/main/kotlin/socialpublish/backend/server/routes/LinkedInRoutes.kt
@@ -4,17 +4,12 @@ import arrow.core.getOrElse
 import io.ktor.http.Cookie
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
-import io.ktor.server.request.receive
-import io.ktor.server.request.receiveParameters
-import io.ktor.server.response.header
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondRedirect
-import java.net.URLEncoder
 import kotlinx.serialization.Serializable
 import socialpublish.backend.clients.linkedin.LinkedInApiModule
 import socialpublish.backend.clients.linkedin.LinkedInConfig
 import socialpublish.backend.common.ErrorResponse
-import socialpublish.backend.common.NewPostRequest
 import socialpublish.backend.db.DocumentsDatabase
 import socialpublish.backend.db.UserSession
 import socialpublish.backend.server.respondWithInternalServerError
@@ -35,27 +30,12 @@ class LinkedInRoutes(
         linkedInConfig: LinkedInConfig,
         call: ApplicationCall,
     ) {
-        val userUuid = userUuid()
         val state = linkedInModule.generateOAuthState()
 
-        call.response.cookies.append(
-            Cookie(
-                name = "linkedin-oauth-state",
-                value = state,
-                maxAge = 600,
-                path = "/",
-                httpOnly = true,
-                extensions = mapOf("SameSite" to "Lax"),
-            )
-        )
+        call.setOAuthStateCookie(state, maxAge = 600)
 
         when (
-            val result =
-                linkedInModule.buildAuthorizeURL(
-                    linkedInConfig,
-                    userUuid,
-                    state,
-                )
+            val result = linkedInModule.buildAuthorizeURL(linkedInConfig, state)
         ) {
             is arrow.core.Either.Right -> call.respondRedirect(result.value)
             is arrow.core.Either.Left -> {
@@ -81,16 +61,7 @@ class LinkedInRoutes(
 
         // Clear the OAuth state cookie
         val cookieState = call.request.cookies["linkedin-oauth-state"]
-        call.response.cookies.append(
-            Cookie(
-                name = "linkedin-oauth-state",
-                value = "",
-                maxAge = 0,
-                path = "/",
-                httpOnly = true,
-                extensions = mapOf("SameSite" to "Lax"),
-            )
-        )
+        call.setOAuthStateCookie("", maxAge = 0)
 
         if (error != null) {
             val userMessage =
@@ -100,39 +71,24 @@ class LinkedInRoutes(
                         "LinkedIn authorization was declined."
                     else -> errorDescription ?: "LinkedIn authorization failed."
                 }
-            call.respondRedirect(
-                "/account?error=${URLEncoder.encode(userMessage, Charsets.UTF_8)}"
-            )
+            call.redirectToAccountError(userMessage)
             return
         }
 
         if (callbackState.isNullOrBlank()) {
-            val msg =
-                URLEncoder.encode(
-                    "LinkedIn authorization could not be verified. Please try again.",
-                    Charsets.UTF_8,
-                )
-            call.respondRedirect("/account?error=$msg")
+            call.redirectToLinkedInVerificationError()
             return
         }
 
         if (cookieState != callbackState) {
-            val msg =
-                URLEncoder.encode(
-                    "LinkedIn authorization could not be verified. Please try again.",
-                    Charsets.UTF_8,
-                )
-            call.respondRedirect("/account?error=$msg")
+            call.redirectToLinkedInVerificationError()
             return
         }
 
         if (code == null) {
-            val msg =
-                URLEncoder.encode(
-                    "LinkedIn did not return an authorization code. Please try again.",
-                    Charsets.UTF_8,
-                )
-            call.respondRedirect("/account?error=$msg")
+            call.redirectToAccountError(
+                "LinkedIn did not return an authorization code. Please try again."
+            )
             return
         }
 
@@ -153,32 +109,15 @@ class LinkedInRoutes(
                         )
                 ) {
                     is arrow.core.Either.Right -> {
-                        call.response.header(
-                            "Cache-Control",
-                            "no-store, no-cache, must-revalidate, private",
-                        )
-                        call.response.header("Pragma", "no-cache")
-                        call.response.header("Expires", "0")
+                        call.preventOAuthRedirectCaching()
                         call.respondRedirect("/account")
                     }
-                    is arrow.core.Either.Left -> {
-                        val msg =
-                            URLEncoder.encode(
-                                "LinkedIn authorization failed. Please try again.",
-                                Charsets.UTF_8,
-                            )
-                        call.respondRedirect("/account?error=$msg")
-                    }
+                    is arrow.core.Either.Left ->
+                        call.redirectToLinkedInAuthorizationFailed()
                 }
             }
-            is arrow.core.Either.Left -> {
-                val msg =
-                    URLEncoder.encode(
-                        "LinkedIn authorization failed. Please try again.",
-                        Charsets.UTF_8,
-                    )
-                call.respondRedirect("/account?error=$msg")
-            }
+            is arrow.core.Either.Left ->
+                call.redirectToLinkedInAuthorizationFailed()
         }
     }
 
@@ -205,19 +144,7 @@ class LinkedInRoutes(
         linkedInConfig: LinkedInConfig,
         call: ApplicationCall,
     ) {
-        val request =
-            runCatching { call.receive<NewPostRequest>() }.getOrNull()
-                ?: run {
-                    val params = call.receiveParameters()
-                    NewPostRequest(
-                        content = params["content"] ?: "",
-                        targets = params.getAll("targets"),
-                        link = params["link"],
-                        language = params["language"],
-                        cleanupHtml = params["cleanupHtml"]?.toBoolean(),
-                        images = params.getAll("images"),
-                    )
-                }
+        val request = call.receiveNewPostRequest()
 
         when (val result = linkedInModule.createPost(linkedInConfig, request)) {
             is arrow.core.Either.Right -> call.respond(result.value)
@@ -230,4 +157,31 @@ class LinkedInRoutes(
             }
         }
     }
+
+    private fun ApplicationCall.setOAuthStateCookie(
+        value: String,
+        maxAge: Int,
+    ) {
+        response.cookies.append(
+            Cookie(
+                name = "linkedin-oauth-state",
+                value = value,
+                maxAge = maxAge,
+                path = "/",
+                httpOnly = true,
+                extensions = mapOf("SameSite" to "Lax"),
+            )
+        )
+    }
+
+    private suspend fun ApplicationCall.redirectToLinkedInVerificationError() =
+        redirectToAccountError(
+            "LinkedIn authorization could not be verified. Please try again."
+        )
+
+    private suspend fun ApplicationCall
+        .redirectToLinkedInAuthorizationFailed() =
+        redirectToAccountError(
+            "LinkedIn authorization failed. Please try again."
+        )
 }

--- a/backend/src/main/kotlin/socialpublish/backend/server/routes/LinkedInRoutes.kt
+++ b/backend/src/main/kotlin/socialpublish/backend/server/routes/LinkedInRoutes.kt
@@ -1,6 +1,7 @@
 package socialpublish.backend.server.routes
 
 import arrow.core.getOrElse
+import io.ktor.http.Cookie
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receive
@@ -32,16 +33,27 @@ class LinkedInRoutes(
     context(_: UserSession)
     suspend fun authorizeRoute(
         linkedInConfig: LinkedInConfig,
-        sessionToken: String,
         call: ApplicationCall,
     ) {
         val userUuid = userUuid()
+        val state = linkedInModule.generateOAuthState()
+
+        call.response.cookies.append(
+            Cookie(
+                name = "linkedin-oauth-state",
+                value = state,
+                maxAge = 600,
+                path = "/",
+                httpOnly = true,
+            )
+        )
+
         when (
             val result =
                 linkedInModule.buildAuthorizeURL(
                     linkedInConfig,
-                    sessionToken,
                     userUuid,
+                    state,
                 )
         ) {
             is arrow.core.Either.Right -> call.respondRedirect(result.value)
@@ -62,20 +74,29 @@ class LinkedInRoutes(
     ) {
         val userUuid = userUuid()
         val code = call.request.queryParameters["code"]
-        val state = call.request.queryParameters["state"]
-        val accessToken = call.request.queryParameters["access_token"]
+        val callbackState = call.request.queryParameters["state"]
         val error = call.request.queryParameters["error"]
         val errorDescription = call.request.queryParameters["error_description"]
+
+        // Clear the OAuth state cookie
+        val cookieState = call.request.cookies["linkedin-oauth-state"]
+        call.response.cookies.append(
+            Cookie(
+                name = "linkedin-oauth-state",
+                value = "",
+                maxAge = 0,
+                path = "/",
+                httpOnly = true,
+            )
+        )
 
         if (error != null) {
             val userMessage =
                 when (error) {
-                    "user_cancelled_login" -> "You cancelled the LinkedIn login"
+                    "user_cancelled_login" -> "LinkedIn login was cancelled."
                     "user_cancelled_authorize" ->
-                        "You declined the LinkedIn authorization request"
-                    else ->
-                        errorDescription
-                            ?: "LinkedIn authorization failed: $error"
+                        "LinkedIn authorization was declined."
+                    else -> errorDescription ?: "LinkedIn authorization failed."
                 }
             call.respondRedirect(
                 "/account?error=${URLEncoder.encode(userMessage, Charsets.UTF_8)}"
@@ -83,43 +104,42 @@ class LinkedInRoutes(
             return
         }
 
-        if (state != null) {
-            val storedSessionToken =
-                linkedInModule.verifyOAuthState(state, userUuid)
-            if (storedSessionToken == null) {
-                val msg =
-                    URLEncoder.encode(
-                        "Authorization failed: Invalid state parameter. Please try again.",
-                        Charsets.UTF_8,
-                    )
-                call.respondRedirect("/account?error=$msg")
-                return
-            }
-        }
-
-        if (code == null) {
+        if (callbackState.isNullOrBlank()) {
             val msg =
                 URLEncoder.encode(
-                    "LinkedIn authorization failed: missing code",
+                    "LinkedIn authorization could not be verified. Please try again.",
                     Charsets.UTF_8,
                 )
             call.respondRedirect("/account?error=$msg")
             return
         }
 
-        val redirectUri =
-            if (accessToken != null) {
-                "${linkedInModule.baseUrl}/api/linkedin/callback?access_token=${URLEncoder.encode(accessToken, Charsets.UTF_8)}"
-            } else {
-                "${linkedInModule.baseUrl}/api/linkedin/callback"
-            }
+        if (cookieState != callbackState) {
+            val msg =
+                URLEncoder.encode(
+                    "LinkedIn authorization could not be verified. Please try again.",
+                    Charsets.UTF_8,
+                )
+            call.respondRedirect("/account?error=$msg")
+            return
+        }
+
+        if (code == null) {
+            val msg =
+                URLEncoder.encode(
+                    "LinkedIn did not return an authorization code. Please try again.",
+                    Charsets.UTF_8,
+                )
+            call.respondRedirect("/account?error=$msg")
+            return
+        }
 
         when (
             val tokenResult =
                 linkedInModule.exchangeCodeForToken(
                     linkedInConfig,
                     code,
-                    redirectUri,
+                    "${linkedInModule.baseUrl}/api/linkedin/callback",
                 )
         ) {
             is arrow.core.Either.Right -> {
@@ -142,7 +162,7 @@ class LinkedInRoutes(
                     is arrow.core.Either.Left -> {
                         val msg =
                             URLEncoder.encode(
-                                saveResult.value.errorMessage,
+                                "LinkedIn authorization failed. Please try again.",
                                 Charsets.UTF_8,
                             )
                         call.respondRedirect("/account?error=$msg")
@@ -152,7 +172,7 @@ class LinkedInRoutes(
             is arrow.core.Either.Left -> {
                 val msg =
                     URLEncoder.encode(
-                        tokenResult.value.errorMessage,
+                        "LinkedIn authorization failed. Please try again.",
                         Charsets.UTF_8,
                     )
                 call.respondRedirect("/account?error=$msg")

--- a/backend/src/main/kotlin/socialpublish/backend/server/routes/RouteHelpers.kt
+++ b/backend/src/main/kotlin/socialpublish/backend/server/routes/RouteHelpers.kt
@@ -1,0 +1,37 @@
+package socialpublish.backend.server.routes
+
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receive
+import io.ktor.server.request.receiveParameters
+import io.ktor.server.response.header
+import io.ktor.server.response.respondRedirect
+import java.net.URLEncoder
+import socialpublish.backend.common.NewPostRequest
+
+suspend fun ApplicationCall.receiveNewPostRequest(): NewPostRequest =
+    runCatching { receive<NewPostRequest>() }.getOrNull()
+        ?: receiveParameters().let { params ->
+            NewPostRequest(
+                content = params["content"] ?: "",
+                targets = params.getAll("targets"),
+                link = params["link"],
+                language = params["language"],
+                cleanupHtml = params["cleanupHtml"]?.toBoolean(),
+                images = params.getAll("images"),
+            )
+        }
+
+fun ApplicationCall.preventOAuthRedirectCaching() {
+    response.header(
+        "Cache-Control",
+        "no-store, no-cache, must-revalidate, private",
+    )
+    response.header("Pragma", "no-cache")
+    response.header("Expires", "0")
+}
+
+suspend fun ApplicationCall.redirectToAccountError(message: String) {
+    respondRedirect(
+        "/account?error=${URLEncoder.encode(message, Charsets.UTF_8)}"
+    )
+}

--- a/backend/src/main/kotlin/socialpublish/backend/server/routes/TwitterRoutes.kt
+++ b/backend/src/main/kotlin/socialpublish/backend/server/routes/TwitterRoutes.kt
@@ -8,6 +8,7 @@ import io.ktor.server.request.receiveParameters
 import io.ktor.server.response.header
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondRedirect
+import java.net.URLEncoder
 import kotlinx.serialization.Serializable
 import socialpublish.backend.clients.twitter.TwitterApiModule
 import socialpublish.backend.clients.twitter.TwitterConfig
@@ -31,12 +32,12 @@ class TwitterRoutes(
     context(_: UserSession)
     suspend fun authorizeRoute(
         twitterConfig: TwitterConfig,
-        sessionToken: String,
         call: ApplicationCall,
     ) {
+        val userUuid = userUuid()
         when (
             val result =
-                twitterModule.buildAuthorizeURL(twitterConfig, sessionToken)
+                twitterModule.buildAuthorizeURL(twitterConfig, userUuid)
         ) {
             is arrow.core.Either.Right -> call.respondRedirect(result.value)
             is arrow.core.Either.Left -> {
@@ -59,9 +60,8 @@ class TwitterRoutes(
         val verifier = call.request.queryParameters["oauth_verifier"]
 
         if (token == null || verifier == null) {
-            call.respond(
-                HttpStatusCode.BadRequest,
-                ErrorResponse(error = "Invalid request"),
+            call.respondRedirect(
+                "/account?error=${URLEncoder.encode("Twitter authorization was incomplete. Please try again.", Charsets.UTF_8)}"
             )
             return
         }
@@ -85,11 +85,12 @@ class TwitterRoutes(
                 call.respondRedirect("/account")
             }
             is arrow.core.Either.Left -> {
-                val error = result.value
-                call.respond(
-                    HttpStatusCode.fromValue(error.status),
-                    ErrorResponse(error = error.errorMessage),
-                )
+                val msg =
+                    URLEncoder.encode(
+                        "Twitter authorization failed. Please try again.",
+                        Charsets.UTF_8,
+                    )
+                call.respondRedirect("/account?error=$msg")
             }
         }
     }

--- a/backend/src/main/kotlin/socialpublish/backend/server/routes/TwitterRoutes.kt
+++ b/backend/src/main/kotlin/socialpublish/backend/server/routes/TwitterRoutes.kt
@@ -105,9 +105,11 @@ class TwitterRoutes(
                     call.respondWithInternalServerError(error)
                     return
                 }
+        val hasAuthorization =
+            row != null && twitterModule.hasValidAccessToken(row.payload)
         call.respond(
             TwitterStatusResponse(
-                hasAuthorization = row != null,
+                hasAuthorization = hasAuthorization,
                 createdAt = row?.createdAt?.toEpochMilli(),
             )
         )

--- a/backend/src/main/kotlin/socialpublish/backend/server/routes/TwitterRoutes.kt
+++ b/backend/src/main/kotlin/socialpublish/backend/server/routes/TwitterRoutes.kt
@@ -3,17 +3,12 @@ package socialpublish.backend.server.routes
 import arrow.core.getOrElse
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
-import io.ktor.server.request.receive
-import io.ktor.server.request.receiveParameters
-import io.ktor.server.response.header
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondRedirect
-import java.net.URLEncoder
 import kotlinx.serialization.Serializable
 import socialpublish.backend.clients.twitter.TwitterApiModule
 import socialpublish.backend.clients.twitter.TwitterConfig
 import socialpublish.backend.common.ErrorResponse
-import socialpublish.backend.common.NewPostRequest
 import socialpublish.backend.db.DocumentsDatabase
 import socialpublish.backend.db.UserSession
 import socialpublish.backend.server.respondWithInternalServerError
@@ -60,8 +55,8 @@ class TwitterRoutes(
         val verifier = call.request.queryParameters["oauth_verifier"]
 
         if (token == null || verifier == null) {
-            call.respondRedirect(
-                "/account?error=${URLEncoder.encode("Twitter authorization was incomplete. Please try again.", Charsets.UTF_8)}"
+            call.redirectToAccountError(
+                "Twitter authorization was incomplete. Please try again."
             )
             return
         }
@@ -76,22 +71,13 @@ class TwitterRoutes(
                 )
         ) {
             is arrow.core.Either.Right -> {
-                call.response.header(
-                    "Cache-Control",
-                    "no-store, no-cache, must-revalidate, private",
-                )
-                call.response.header("Pragma", "no-cache")
-                call.response.header("Expires", "0")
+                call.preventOAuthRedirectCaching()
                 call.respondRedirect("/account")
             }
-            is arrow.core.Either.Left -> {
-                val msg =
-                    URLEncoder.encode(
-                        "Twitter authorization failed. Please try again.",
-                        Charsets.UTF_8,
-                    )
-                call.respondRedirect("/account?error=$msg")
-            }
+            is arrow.core.Either.Left ->
+                call.redirectToAccountError(
+                    "Twitter authorization failed. Please try again."
+                )
         }
     }
 
@@ -120,19 +106,7 @@ class TwitterRoutes(
         twitterConfig: TwitterConfig,
         call: ApplicationCall,
     ) {
-        val request =
-            runCatching { call.receive<NewPostRequest>() }.getOrNull()
-                ?: run {
-                    val params = call.receiveParameters()
-                    NewPostRequest(
-                        content = params["content"] ?: "",
-                        targets = params.getAll("targets"),
-                        link = params["link"],
-                        language = params["language"],
-                        cleanupHtml = params["cleanupHtml"]?.toBoolean(),
-                        images = params.getAll("images"),
-                    )
-                }
+        val request = call.receiveNewPostRequest()
 
         when (val result = twitterModule.createPost(twitterConfig, request)) {
             is arrow.core.Either.Right -> call.respond(result.value)

--- a/backend/src/test/kotlin/socialpublish/backend/clients/linkedin/LinkedInApiTest.kt
+++ b/backend/src/test/kotlin/socialpublish/backend/clients/linkedin/LinkedInApiTest.kt
@@ -81,8 +81,8 @@ class LinkedInApiTest {
             val result =
                 module.buildAuthorizeURL(
                     config,
-                    "test-session-token",
                     UUIDv7.fromString("00000000-0000-0000-0000-000000000001"),
+                    "test-state-value",
                 )
 
             assertTrue(result is Either.Right)

--- a/backend/src/test/kotlin/socialpublish/backend/clients/linkedin/LinkedInApiTest.kt
+++ b/backend/src/test/kotlin/socialpublish/backend/clients/linkedin/LinkedInApiTest.kt
@@ -78,12 +78,7 @@ class LinkedInApiTest {
                     linkPreview,
                 )
 
-            val result =
-                module.buildAuthorizeURL(
-                    config,
-                    UUIDv7.fromString("00000000-0000-0000-0000-000000000001"),
-                    "test-state-value",
-                )
+            val result = module.buildAuthorizeURL(config, "test-state-value")
 
             assertTrue(result is Either.Right)
             val url = (result as Either.Right).value

--- a/backend/src/test/kotlin/socialpublish/backend/clients/twitter/TwitterOAuthDocumentSerializationTest.kt
+++ b/backend/src/test/kotlin/socialpublish/backend/clients/twitter/TwitterOAuthDocumentSerializationTest.kt
@@ -1,0 +1,80 @@
+package socialpublish.backend.clients.twitter
+
+import arrow.core.Either
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class TwitterOAuthDocumentSerializationTest {
+    @Test
+    fun `parse reads new wrapper format with access token`() {
+        val payload =
+            """{"accessToken":{"key":"access-key","secret":"access-secret"},"pendingRequest":null}"""
+
+        val parsed = TwitterOAuthDocument.parse(payload)
+
+        val document =
+            assertIs<Either.Right<TwitterOAuthDocument>>(parsed).value
+        assertEquals(
+            TwitterOAuthToken("access-key", "access-secret"),
+            document.accessToken,
+        )
+        assertNull(document.pendingRequest)
+    }
+
+    @Test
+    fun `parse reads new wrapper format with pending request`() {
+        val payload =
+            """{"accessToken":null,"pendingRequest":{"token":"request-token","secret":"request-secret"}}"""
+
+        val parsed = TwitterOAuthDocument.parse(payload)
+
+        val document =
+            assertIs<Either.Right<TwitterOAuthDocument>>(parsed).value
+        assertNull(document.accessToken)
+        assertEquals(
+            TwitterOAuthRequestToken("request-token", "request-secret"),
+            document.pendingRequest,
+        )
+    }
+
+    @Test
+    fun `parse reads old bare token format`() {
+        val payload = """{"key":"old-key","secret":"old-secret"}"""
+
+        val parsed = TwitterOAuthDocument.parse(payload)
+
+        val document =
+            assertIs<Either.Right<TwitterOAuthDocument>>(parsed).value
+        assertEquals(
+            TwitterOAuthToken("old-key", "old-secret"),
+            document.accessToken,
+        )
+        assertNull(document.pendingRequest)
+    }
+
+    @Test
+    fun `parse returns error for invalid payload`() {
+        val parsed = TwitterOAuthDocument.parse("not json")
+
+        assertIs<Either.Left<IllegalArgumentException>>(parsed)
+    }
+
+    @Test
+    fun `serialized document round trips through parser`() {
+        val document =
+            TwitterOAuthDocument(
+                accessToken = TwitterOAuthToken("access-key", "access-secret"),
+                pendingRequest =
+                    TwitterOAuthRequestToken("request-token", "request-secret"),
+            )
+
+        val parsed = TwitterOAuthDocument.parse(document.toJson())
+
+        assertEquals(
+            document,
+            assertIs<Either.Right<TwitterOAuthDocument>>(parsed).value,
+        )
+    }
+}

--- a/backend/src/test/kotlin/socialpublish/backend/modules/EndpointSecurityTest.kt
+++ b/backend/src/test/kotlin/socialpublish/backend/modules/EndpointSecurityTest.kt
@@ -187,7 +187,7 @@ class EndpointSecurityTest {
     }
 
     @Test
-    fun `protected endpoint should accept requests with valid token via query parameter`() {
+    fun `protected endpoint should reject requests with token via query parameter`() {
         testApplication {
             val ctx = createTestContext()
 
@@ -213,7 +213,7 @@ class EndpointSecurityTest {
             val response =
                 client.get("/api/protected?access_token=${ctx.token}")
 
-            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
         }
     }
 

--- a/backend/src/test/kotlin/socialpublish/backend/server/routes/AuthRoutesTest.kt
+++ b/backend/src/test/kotlin/socialpublish/backend/server/routes/AuthRoutesTest.kt
@@ -509,7 +509,7 @@ class AuthRoutesTest {
     }
 
     @Test
-    fun `protectedRoute should accept valid token via access_token query parameter`() {
+    fun `protectedRoute should reject valid token via access_token query parameter`() {
         testApplication {
             val ctx = testSetup()
             val token = loginAndGetToken(ctx)
@@ -527,7 +527,7 @@ class AuthRoutesTest {
 
             val response = client.get("/api/protected?access_token=$token")
 
-            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
         }
     }
 
@@ -664,7 +664,7 @@ class AuthRoutesTest {
     }
 
     @Test
-    fun `extractAccessToken should extract token from access_token query parameter`() {
+    fun `extractAccessToken should not extract token from access_token query parameter`() {
         testApplication {
             val ctx = testSetup()
             application {
@@ -680,7 +680,7 @@ class AuthRoutesTest {
             val response = client.get("/test?access_token=query-token-789")
 
             assertEquals(HttpStatusCode.OK, response.status)
-            assertTrue(response.bodyAsText().contains("query-token-789"))
+            assertTrue(response.bodyAsText().contains("\"token\":null"))
         }
     }
 

--- a/backend/src/test/kotlin/socialpublish/backend/server/routes/LinkedInRoutesAuthorizeTest.kt
+++ b/backend/src/test/kotlin/socialpublish/backend/server/routes/LinkedInRoutesAuthorizeTest.kt
@@ -1,6 +1,5 @@
 package socialpublish.backend.server.routes
 
-import arrow.core.getOrElse
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
@@ -10,7 +9,6 @@ import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import java.nio.file.Path
 import kotlin.test.Test
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.io.TempDir
@@ -26,10 +24,9 @@ import socialpublish.backend.testutils.createTestSession
 class LinkedInRoutesAuthorizeTest {
     private val testUserUuid =
         UUIDv7.fromString("00000000-0000-0000-0000-000000000001")
-    private val callbackSessionToken = "trusted-callback-session-token"
 
     @Test
-    fun `authorize uses provided callback session token`(
+    fun `authorize succeeds and sets OAuth state cookie`(
         @TempDir tempDir: Path
     ) = testApplication {
         val db = createTestDatabase(tempDir)
@@ -67,11 +64,7 @@ class LinkedInRoutesAuthorizeTest {
             routing {
                 get("/api/linkedin/authorize") {
                     context(createTestSession(testUserUuid)) {
-                        routes.authorizeRoute(
-                            config,
-                            callbackSessionToken,
-                            call,
-                        )
+                        routes.authorizeRoute(config, call)
                     }
                 }
             }
@@ -83,90 +76,53 @@ class LinkedInRoutesAuthorizeTest {
             response.status != HttpStatusCode.Unauthorized,
             "Expected authorize flow to succeed, got ${response.status}",
         )
-
-        val states =
-            documentsDb
-                .getAllForUser(
-                    kind = "linkedin-oauth-state",
-                    userUuid = testUserUuid,
-                )
-                .getOrElse { throw it }
-        assertTrue(states.isNotEmpty())
-        assertTrue(
-            states.first().payload.contains("trusted-callback-session-token")
-        )
     }
 
     @Test
-    fun `authorize ignores request access_token query override`(
-        @TempDir tempDir: Path
-    ) = testApplication {
-        val db = createTestDatabase(tempDir)
-        val filesModule = createFilesModule(tempDir, db)
-        val documentsDb = DocumentsDatabase(db)
+    fun `authorize generates unique state each call`(@TempDir tempDir: Path) =
+        testApplication {
+            val db = createTestDatabase(tempDir)
+            val filesModule = createFilesModule(tempDir, db)
+            val documentsDb = DocumentsDatabase(db)
 
-        val linkedInClient = createClient {
-            install(ClientContentNegotiation) {
-                json(
-                    Json {
-                        ignoreUnknownKeys = true
-                        isLenient = true
-                    }
-                )
-            }
-        }
-        val linkPreview = LinkPreviewParser(httpClient = linkedInClient)
-        val linkedInModule =
-            LinkedInApiModule(
-                "http://localhost",
-                documentsDb,
-                filesModule,
-                linkedInClient.engine,
-                linkPreview,
-            )
-        val routes = LinkedInRoutes(linkedInModule, documentsDb)
-        val config =
-            LinkedInConfig(
-                clientId = "client-id",
-                clientSecret = "client-secret",
-                authorizationUrl = "http://localhost/oauth/v2/authorization",
-            )
-
-        application {
-            routing {
-                get("/api/linkedin/authorize") {
-                    context(createTestSession(testUserUuid)) {
-                        routes.authorizeRoute(
-                            config,
-                            callbackSessionToken,
-                            call,
-                        )
-                    }
+            val linkedInClient = createClient {
+                install(ClientContentNegotiation) {
+                    json(
+                        Json {
+                            ignoreUnknownKeys = true
+                            isLenient = true
+                        }
+                    )
                 }
             }
-        }
-
-        val queryResponse =
-            client.get(
-                "/api/linkedin/authorize?access_token=attacker-controlled-token"
-            )
-        assertTrue(
-            queryResponse.status != HttpStatusCode.Unauthorized,
-            "Expected authorize flow to succeed, got ${queryResponse.status}",
-        )
-        val states =
-            documentsDb
-                .getAllForUser(
-                    kind = "linkedin-oauth-state",
-                    userUuid = testUserUuid,
+            val linkPreview = LinkPreviewParser(httpClient = linkedInClient)
+            val linkedInModule =
+                LinkedInApiModule(
+                    "http://localhost",
+                    documentsDb,
+                    filesModule,
+                    linkedInClient.engine,
+                    linkPreview,
                 )
-                .getOrElse { throw it }
-        assertTrue(states.isNotEmpty())
-        assertTrue(
-            states.first().payload.contains("trusted-callback-session-token")
-        )
-        assertFalse(
-            states.first().payload.contains("attacker-controlled-token")
-        )
-    }
+            val routes = LinkedInRoutes(linkedInModule, documentsDb)
+            val config =
+                LinkedInConfig(
+                    clientId = "client-id",
+                    clientSecret = "client-secret",
+                    authorizationUrl = "http://localhost/oauth/v2/authorization",
+                )
+
+            // generateOAuthState should return unique values
+            val state1 = linkedInModule.generateOAuthState()
+            val state2 = linkedInModule.generateOAuthState()
+            val state3 = linkedInModule.generateOAuthState()
+
+            assertTrue(state1 != state2, "Expected different states")
+            assertTrue(state1 != state3, "Expected different states")
+            assertTrue(state2 != state3, "Expected different states")
+            assertTrue(
+                state1.length >= 32,
+                "Expected state to be at least 32 chars",
+            )
+        }
 }

--- a/backend/src/test/kotlin/socialpublish/backend/server/routes/LinkedInRoutesAuthorizeTest.kt
+++ b/backend/src/test/kotlin/socialpublish/backend/server/routes/LinkedInRoutesAuthorizeTest.kt
@@ -2,6 +2,7 @@ package socialpublish.backend.server.routes
 
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
 import io.ktor.client.request.get
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.routing.get
@@ -9,7 +10,9 @@ import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import java.nio.file.Path
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.io.TempDir
 import socialpublish.backend.clients.linkedin.LinkedInApiModule
@@ -70,59 +73,73 @@ class LinkedInRoutesAuthorizeTest {
             }
         }
 
-        val response = client.get("/api/linkedin/authorize")
+        val response =
+            createClient { followRedirects = false }
+                .get("/api/linkedin/authorize")
 
         assertTrue(
             response.status != HttpStatusCode.Unauthorized,
             "Expected authorize flow to succeed, got ${response.status}",
         )
+        val stateCookie =
+            response.headers.getAll(HttpHeaders.SetCookie)?.singleOrNull {
+                it.startsWith("linkedin-oauth-state=")
+            }
+        assertNotNull(stateCookie)
+        assertTrue(stateCookie.contains("HttpOnly"))
+        assertTrue(stateCookie.contains("Path=/"))
+        assertTrue(stateCookie.contains("Max-Age=600"))
+        assertTrue(stateCookie.contains("SameSite=Lax"))
     }
 
     @Test
     fun `authorize generates unique state each call`(@TempDir tempDir: Path) =
-        testApplication {
-            val db = createTestDatabase(tempDir)
-            val filesModule = createFilesModule(tempDir, db)
-            val documentsDb = DocumentsDatabase(db)
+        runTest {
+            testApplication {
+                val db = createTestDatabase(tempDir)
+                val filesModule = createFilesModule(tempDir, db)
+                val documentsDb = DocumentsDatabase(db)
 
-            val linkedInClient = createClient {
-                install(ClientContentNegotiation) {
-                    json(
-                        Json {
-                            ignoreUnknownKeys = true
-                            isLenient = true
-                        }
-                    )
+                val linkedInClient = createClient {
+                    install(ClientContentNegotiation) {
+                        json(
+                            Json {
+                                ignoreUnknownKeys = true
+                                isLenient = true
+                            }
+                        )
+                    }
                 }
+                val linkPreview = LinkPreviewParser(httpClient = linkedInClient)
+                val linkedInModule =
+                    LinkedInApiModule(
+                        "http://localhost",
+                        documentsDb,
+                        filesModule,
+                        linkedInClient.engine,
+                        linkPreview,
+                    )
+                val routes = LinkedInRoutes(linkedInModule, documentsDb)
+                val config =
+                    LinkedInConfig(
+                        clientId = "client-id",
+                        clientSecret = "client-secret",
+                        authorizationUrl =
+                            "http://localhost/oauth/v2/authorization",
+                    )
+
+                // generateOAuthState should return unique values
+                val state1 = linkedInModule.generateOAuthState()
+                val state2 = linkedInModule.generateOAuthState()
+                val state3 = linkedInModule.generateOAuthState()
+
+                assertTrue(state1 != state2, "Expected different states")
+                assertTrue(state1 != state3, "Expected different states")
+                assertTrue(state2 != state3, "Expected different states")
+                assertTrue(
+                    state1.length >= 32,
+                    "Expected state to be at least 32 chars",
+                )
             }
-            val linkPreview = LinkPreviewParser(httpClient = linkedInClient)
-            val linkedInModule =
-                LinkedInApiModule(
-                    "http://localhost",
-                    documentsDb,
-                    filesModule,
-                    linkedInClient.engine,
-                    linkPreview,
-                )
-            val routes = LinkedInRoutes(linkedInModule, documentsDb)
-            val config =
-                LinkedInConfig(
-                    clientId = "client-id",
-                    clientSecret = "client-secret",
-                    authorizationUrl = "http://localhost/oauth/v2/authorization",
-                )
-
-            // generateOAuthState should return unique values
-            val state1 = linkedInModule.generateOAuthState()
-            val state2 = linkedInModule.generateOAuthState()
-            val state3 = linkedInModule.generateOAuthState()
-
-            assertTrue(state1 != state2, "Expected different states")
-            assertTrue(state1 != state3, "Expected different states")
-            assertTrue(state2 != state3, "Expected different states")
-            assertTrue(
-                state1.length >= 32,
-                "Expected state to be at least 32 chars",
-            )
         }
 }

--- a/backend/src/test/kotlin/socialpublish/backend/server/routes/LinkedInRoutesCallbackTest.kt
+++ b/backend/src/test/kotlin/socialpublish/backend/server/routes/LinkedInRoutesCallbackTest.kt
@@ -1,0 +1,139 @@
+package socialpublish.backend.server.routes
+
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.io.TempDir
+import socialpublish.backend.clients.linkedin.LinkedInApiModule
+import socialpublish.backend.clients.linkedin.LinkedInConfig
+import socialpublish.backend.clients.linkpreview.LinkPreviewParser
+import socialpublish.backend.db.DocumentsDatabase
+import socialpublish.backend.db.UUIDv7
+import socialpublish.backend.testutils.createFilesModule
+import socialpublish.backend.testutils.createTestDatabase
+import socialpublish.backend.testutils.createTestSession
+
+class LinkedInRoutesCallbackTest {
+    private val testUserUuid =
+        UUIDv7.fromString("00000000-0000-0000-0000-000000000001")
+
+    @Test
+    fun `callback with missing state redirects with error and clears state cookie`(
+        @TempDir tempDir: Path
+    ) = testApplication {
+        val routes = createRoutes(tempDir)
+        val config =
+            LinkedInConfig(clientId = "client-id", clientSecret = "secret")
+
+        application {
+            routing {
+                get("/api/linkedin/callback") {
+                    context(createTestSession(testUserUuid)) {
+                        routes.callbackRoute(config, call)
+                    }
+                }
+            }
+        }
+
+        val response =
+            createClient { followRedirects = false }
+                .get("/api/linkedin/callback?code=abc") {
+                    header(
+                        HttpHeaders.Cookie,
+                        "linkedin-oauth-state=expected-state",
+                    )
+                }
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertTrue(
+            response.headers[HttpHeaders.Location]?.startsWith(
+                "/account?error="
+            ) == true
+        )
+        val clearedCookie =
+            response.headers.getAll(HttpHeaders.SetCookie)?.singleOrNull {
+                it.startsWith("linkedin-oauth-state=")
+            }
+        assertNotNull(clearedCookie)
+        assertTrue(clearedCookie.contains("Max-Age=0"))
+        assertTrue(clearedCookie.contains("Path=/"))
+        assertTrue(clearedCookie.contains("HttpOnly"))
+        assertTrue(clearedCookie.contains("SameSite=Lax"))
+    }
+
+    @Test
+    fun `callback with mismatched state redirects with verification error`(
+        @TempDir tempDir: Path
+    ) = testApplication {
+        val routes = createRoutes(tempDir)
+        val config =
+            LinkedInConfig(clientId = "client-id", clientSecret = "secret")
+
+        application {
+            routing {
+                get("/api/linkedin/callback") {
+                    context(createTestSession(testUserUuid)) {
+                        routes.callbackRoute(config, call)
+                    }
+                }
+            }
+        }
+
+        val response =
+            createClient { followRedirects = false }
+                .get("/api/linkedin/callback?code=abc&state=callback-state") {
+                    header(
+                        HttpHeaders.Cookie,
+                        "linkedin-oauth-state=cookie-state",
+                    )
+                }
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertTrue(
+            response.headers[HttpHeaders.Location]?.startsWith(
+                "/account?error="
+            ) == true
+        )
+    }
+
+    private suspend fun ApplicationTestBuilder.createRoutes(
+        tempDir: Path
+    ): LinkedInRoutes {
+        val db = createTestDatabase(tempDir)
+        val filesModule = createFilesModule(tempDir, db)
+        val documentsDb = DocumentsDatabase(db)
+        val linkedInClient = createClient {
+            install(ClientContentNegotiation) {
+                json(
+                    Json {
+                        ignoreUnknownKeys = true
+                        isLenient = true
+                    }
+                )
+            }
+        }
+        val linkPreview = LinkPreviewParser(httpClient = linkedInClient)
+        val linkedInModule =
+            LinkedInApiModule(
+                "http://localhost",
+                documentsDb,
+                filesModule,
+                linkedInClient.engine,
+                linkPreview,
+            )
+        return LinkedInRoutes(linkedInModule, documentsDb)
+    }
+}

--- a/backend/src/test/kotlin/socialpublish/backend/server/routes/TwitterRoutesAuthorizeTest.kt
+++ b/backend/src/test/kotlin/socialpublish/backend/server/routes/TwitterRoutesAuthorizeTest.kt
@@ -11,7 +11,6 @@ import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import java.nio.file.Path
 import kotlin.test.Test
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.io.TempDir
@@ -26,10 +25,9 @@ import socialpublish.backend.testutils.createTestSession
 class TwitterRoutesAuthorizeTest {
     private val testUserUuid =
         UUIDv7.fromString("00000000-0000-0000-0000-000000000001")
-    private val callbackSessionToken = "trusted-callback-session-token"
 
     @Test
-    fun `authorize uses provided callback session token`(
+    fun `authorize stores pending request token and returns redirect`(
         @TempDir tempDir: Path
     ) = testApplication {
         val db = createTestDatabase(tempDir)
@@ -72,11 +70,7 @@ class TwitterRoutesAuthorizeTest {
                 }
                 get("/api/twitter/authorize") {
                     context(createTestSession(testUserUuid)) {
-                        routes.authorizeRoute(
-                            config,
-                            callbackSessionToken,
-                            call,
-                        )
+                        routes.authorizeRoute(config, call)
                     }
                 }
             }
@@ -87,74 +81,6 @@ class TwitterRoutesAuthorizeTest {
         assertTrue(
             response.status != HttpStatusCode.Unauthorized,
             "Expected authorize flow to succeed, got ${response.status}",
-        )
-    }
-
-    @Test
-    fun `authorize ignores request access_token query override`(
-        @TempDir tempDir: Path
-    ) = testApplication {
-        val db = createTestDatabase(tempDir)
-        val filesModule = createFilesModule(tempDir, db)
-        val documentsDb = DocumentsDatabase(db)
-
-        val twitterClient = createClient {
-            install(ClientContentNegotiation) {
-                json(
-                    Json {
-                        ignoreUnknownKeys = true
-                        isLenient = true
-                    }
-                )
-            }
-        }
-
-        val twitterModule =
-            TwitterApiModule(
-                "http://localhost",
-                documentsDb,
-                filesModule,
-                twitterClient,
-            )
-        val routes = TwitterRoutes(twitterModule, documentsDb)
-        val config =
-            TwitterConfig(
-                oauth1ConsumerKey = "k",
-                oauth1ConsumerSecret = "s",
-                oauthRequestTokenUrl = "http://localhost/oauth/request_token",
-                oauthAuthorizeUrl = "http://localhost/oauth/authorize",
-            )
-
-        application {
-            routing {
-                post("/oauth/request_token") {
-                    call.respondText(
-                        "oauth_token=req123&oauth_token_secret=secret123&oauth_callback_confirmed=true"
-                    )
-                }
-                get("/api/twitter/authorize") {
-                    context(createTestSession(testUserUuid)) {
-                        routes.authorizeRoute(
-                            config,
-                            callbackSessionToken,
-                            call,
-                        )
-                    }
-                }
-            }
-        }
-
-        val queryResponse =
-            client.get(
-                "/api/twitter/authorize?access_token=attacker-controlled-token"
-            )
-        assertTrue(
-            queryResponse.status != HttpStatusCode.Unauthorized,
-            "Expected authorize flow to succeed, got ${queryResponse.status}",
-        )
-        assertFalse(
-            queryResponse.status == HttpStatusCode.Unauthorized,
-            "Expected query param to be ignored for route auth token selection",
         )
     }
 }

--- a/backend/src/test/kotlin/socialpublish/backend/server/routes/TwitterRoutesCallbackTest.kt
+++ b/backend/src/test/kotlin/socialpublish/backend/server/routes/TwitterRoutesCallbackTest.kt
@@ -1,0 +1,213 @@
+package socialpublish.backend.server.routes
+
+import arrow.core.getOrElse
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import java.net.ServerSocket
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.io.TempDir
+import socialpublish.backend.clients.twitter.TwitterApiModule
+import socialpublish.backend.clients.twitter.TwitterConfig
+import socialpublish.backend.clients.twitter.TwitterOAuthDocument
+import socialpublish.backend.clients.twitter.TwitterOAuthRequestToken
+import socialpublish.backend.db.DocumentsDatabase
+import socialpublish.backend.db.UUIDv7
+import socialpublish.backend.testutils.createFilesModule
+import socialpublish.backend.testutils.createTestDatabase
+import socialpublish.backend.testutils.createTestSession
+
+class TwitterRoutesCallbackTest {
+    private val testUserUuid =
+        UUIDv7.fromString("00000000-0000-0000-0000-000000000001")
+
+    @Test
+    fun `callback with missing params redirects with error`(
+        @TempDir tempDir: Path
+    ) = testApplication {
+        val testContext = createRoutes(tempDir)
+        application {
+            routing {
+                get("/api/twitter/callback") {
+                    context(createTestSession(testUserUuid)) {
+                        testContext.routes.callbackRoute(
+                            testContext.config,
+                            call,
+                        )
+                    }
+                }
+            }
+        }
+
+        val response =
+            createClient { followRedirects = false }
+                .get("/api/twitter/callback?oauth_token=req123")
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertTrue(
+            response.headers[HttpHeaders.Location]?.startsWith(
+                "/account?error="
+            ) == true
+        )
+    }
+
+    @Test
+    fun `callback without pending request redirects with error`(
+        @TempDir tempDir: Path
+    ) = testApplication {
+        val testContext = createRoutes(tempDir)
+        application {
+            routing {
+                get("/api/twitter/callback") {
+                    context(createTestSession(testUserUuid)) {
+                        testContext.routes.callbackRoute(
+                            testContext.config,
+                            call,
+                        )
+                    }
+                }
+            }
+        }
+
+        val response =
+            createClient { followRedirects = false }
+                .get(
+                    "/api/twitter/callback?oauth_token=req123&oauth_verifier=verifier"
+                )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertTrue(
+            response.headers[HttpHeaders.Location]?.startsWith(
+                "/account?error="
+            ) == true
+        )
+    }
+
+    @Test
+    fun `callback exchanges stored pending request and clears it`(
+        @TempDir tempDir: Path
+    ) = testApplication {
+        val oauthPort = ServerSocket(0).use { it.localPort }
+        val oauthServer =
+            embeddedServer(CIO, port = oauthPort) {
+                    routing {
+                        post("/oauth/access_token") {
+                            call.respondText(
+                                "oauth_token=access&oauth_token_secret=secret"
+                            )
+                        }
+                    }
+                }
+                .start(wait = false)
+        val oauthBaseUrl = "http://localhost:$oauthPort"
+        val testContext = createRoutes(tempDir, oauthBaseUrl)
+        val _ =
+            testContext.documentsDb
+                .createOrUpdate(
+                    kind = "twitter-oauth-token",
+                    payload =
+                        TwitterOAuthDocument(
+                                pendingRequest =
+                                    TwitterOAuthRequestToken(
+                                        token = "req123",
+                                        secret = "secret123",
+                                    )
+                            )
+                            .toJson(),
+                    userUuid = testUserUuid,
+                    searchKey = "twitter-oauth-token:$testUserUuid",
+                )
+                .getOrElse { throw it }
+
+        application {
+            routing {
+                get("/api/twitter/callback") {
+                    context(createTestSession(testUserUuid)) {
+                        testContext.routes.callbackRoute(
+                            testContext.config,
+                            call,
+                        )
+                    }
+                }
+            }
+        }
+
+        val response =
+            createClient { followRedirects = false }
+                .get(
+                    "/api/twitter/callback?oauth_token=req123&oauth_verifier=verifier"
+                )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+        oauthServer.stop()
+        assertEquals("/account", response.headers[HttpHeaders.Location])
+        val stored =
+            testContext.documentsDb
+                .searchByKey("twitter-oauth-token:$testUserUuid", testUserUuid)
+                .getOrNull()
+        val document =
+            TwitterOAuthDocument.parse(stored?.payload ?: "").getOrNull()
+        assertEquals("access", document?.accessToken?.key)
+        assertNull(document?.pendingRequest)
+    }
+
+    private suspend fun ApplicationTestBuilder.createRoutes(
+        tempDir: Path,
+        oauthBaseUrl: String = "http://localhost",
+    ): TwitterRouteTestContext {
+        val db = createTestDatabase(tempDir)
+        val filesModule = createFilesModule(tempDir, db)
+        val documentsDb = DocumentsDatabase(db)
+        val twitterClient = createClient {
+            install(ClientContentNegotiation) {
+                json(
+                    Json {
+                        ignoreUnknownKeys = true
+                        isLenient = true
+                    }
+                )
+            }
+        }
+        val twitterModule =
+            TwitterApiModule(
+                "http://localhost",
+                documentsDb,
+                filesModule,
+                twitterClient,
+            )
+        val config =
+            TwitterConfig(
+                oauth1ConsumerKey = "key",
+                oauth1ConsumerSecret = "secret",
+                oauthRequestTokenUrl = "$oauthBaseUrl/oauth/request_token",
+                oauthAccessTokenUrl = "$oauthBaseUrl/oauth/access_token",
+                oauthAuthorizeUrl = "$oauthBaseUrl/oauth/authorize",
+            )
+        return TwitterRouteTestContext(
+            routes = TwitterRoutes(twitterModule, documentsDb),
+            config = config,
+            documentsDb = documentsDb,
+        )
+    }
+
+    private data class TwitterRouteTestContext(
+        val routes: TwitterRoutes,
+        val config: TwitterConfig,
+        val documentsDb: DocumentsDatabase,
+    )
+}

--- a/frontend/src/jsMain/kotlin/socialpublish/frontend/pages/AccountPage.kt
+++ b/frontend/src/jsMain/kotlin/socialpublish/frontend/pages/AccountPage.kt
@@ -14,6 +14,7 @@ import org.jetbrains.compose.web.attributes.InputType
 import org.jetbrains.compose.web.css.*
 import org.jetbrains.compose.web.dom.*
 import socialpublish.frontend.components.Authorize
+import socialpublish.frontend.components.ErrorModal
 import socialpublish.frontend.components.PageContainer
 import socialpublish.frontend.components.TextInputField
 import socialpublish.frontend.utils.ApiClient
@@ -175,6 +176,18 @@ fun AccountPage() {
     Authorize {
         var state by remember { mutableStateOf(AccountPageState()) }
         val scope = rememberCoroutineScope()
+
+        // Parse OAuth error from URL query parameter
+        var oauthError by remember {
+            mutableStateOf(URLSearchParams(window.location.search).get("error"))
+        }
+
+        // Clean the URL after reading the error to prevent re-show on refresh
+        LaunchedEffect(oauthError) {
+            if (oauthError != null) {
+                window.history.replaceState(null, "", "/account")
+            }
+        }
 
         LaunchedEffect(Unit) {
             scope.launch {
@@ -388,6 +401,8 @@ fun AccountPage() {
                 }
             }
         }
+
+        ErrorModal(message = oauthError) { oauthError = null }
 
         PageContainer("account") {
             Div(attrs = { classes("block") }) {

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,13 +5,13 @@
       "source": "alexandru/skills",
       "sourceType": "github",
       "skillPath": "skills/arrow-resource/SKILL.md",
-      "computedHash": "ea3921aa5f1416f51612ccc64f94b374a356412453f3fe598d3784970d5fe42c"
+      "computedHash": "1944a581af2a57cea2941ae175668f4b274c32e699d5a626616c3fdbcbe6d662"
     },
     "arrow-typed-errors": {
       "source": "alexandru/skills",
       "sourceType": "github",
       "skillPath": "skills/arrow-typed-errors/SKILL.md",
-      "computedHash": "32bcbbbb894137ca0fbd7ddf71071c2f96526812c170044291d826fb6e1c572c"
+      "computedHash": "a4d1ed6c0643f6b2f7c1f710015421f23786f02647251869b2111c378ccab8f9"
     },
     "compose-state-hoisting": {
       "source": "alexandru/skills",
@@ -24,6 +24,12 @@
       "sourceType": "github",
       "skillPath": "skills/kotlin-context-parameters/SKILL.md",
       "computedHash": "5df194708db7393daa1c2cc67c3aa79aa25847965645d0bec974c5fd9b757bb5"
+    },
+    "simplify": {
+      "source": "alexandru/skills",
+      "sourceType": "github",
+      "skillPath": "skills/simplify/SKILL.md",
+      "computedHash": "c1c25910819652a25ac68063fcf663ba9392d19bcd58d153a1a8fcc92b6721ee"
     }
   }
 }


### PR DESCRIPTION
Hardens the LinkedIn and Twitter OAuth authorization flows and improves callback error UX.

## Changes

### Remove session tokens from OAuth callback URLs

Both LinkedIn and Twitter OAuth flows previously embedded the app session token as `?access_token=...` in callback URLs, exposing it to browser history, proxy logs, and referrers. The app already supports `Authorization: Bearer` header and `access_token` cookie auth.

- Removed `?access_token=...` query-parameter authentication globally (`AuthRoutes.extractAccessToken`)
- Removed `accessTokenQuery` OpenAPI security scheme
- OAuth callback URLs are now bare (`/api/{provider}/callback`)

### LinkedIn: state cookie instead of database persistence

LinkedIn OAuth state was persisted in `DocumentsDatabase`. Replaced with a short-lived `HttpOnly; SameSite=Lax` cookie set during authorize and verified/cleared during callback. This eliminates DB writes for transient OAuth data.

### LinkedIn: callback now requires valid state

Previously the callback accepted requests without a `state` parameter, skipping CSRF verification. The callback now requires a non-blank state matching the cookie value.

### Twitter: persist request-token secret in existing auth document

The OAuth 1.0a request-token secret was discarded between authorize and callback steps. Stored now in the existing `twitter-oauth-token` document alongside the final access token, with backward-compatible deserialization of existing documents.

### Both providers: browser-friendly callback error redirects

All callback failure paths now redirect to `/account?error=<friendly message>` instead of returning JSON errors. The frontend Account page displays these errors via the existing `ErrorModal` component and cleans the URL afterward.

## Files changed

| File | Change |
|---|---|
| `backend/.../routes/AuthRoutes.kt` | Remove query-parameter auth extraction |
| `backend/.../server/openapi.kt` | Remove query auth scheme; update callback response docs |
| `backend/.../clients/linkedin/LinkedInApiModule.kt` | Bare callback URL; remove DB state; public `generateOAuthState()` |
| `backend/.../server/routes/LinkedInRoutes.kt` | State cookie set/verify/clear; require state; friendly error redirects |
| `backend/.../clients/twitter/models.kt` | Add `TwitterOAuthDocument` and `TwitterOAuthRequestToken` |
| `backend/.../clients/twitter/TwitterApiModule.kt` | Store pending request token in existing doc; verify on callback; backward-compat parsing |
| `backend/.../server/routes/TwitterRoutes.kt` | Friendly error redirects; pass `userUuid` to authorize |
| `backend/.../server/Server.kt` | Updated authorize route wiring |
| `frontend/.../pages/AccountPage.kt` | Parse `?error=...` query param; show `ErrorModal`; clean URL |
